### PR TITLE
Fix `FileNotFoundError` in the Aligment step of De Bruijn assembly workflow

### DIFF
--- a/notebooks/dbg_workflow.ipynb
+++ b/notebooks/dbg_workflow.ipynb
@@ -143,8 +143,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_combination_name(ass_method, conf, size_threshold, min_overlap, min_identity, max_mismatches):\n",
-    "    return f\"comb_{ass_method}_c{conf}_ts{size_threshold}_mo{min_overlap}_mi{min_identity}_mm{max_mismatches}\""
+    "def get_combination_name(ass_method, conf, kmer_size, size_threshold, min_overlap, min_identity, max_mismatches):\n",
+    "    return f\"comb_{ass_method}_c{conf}_ks{kmer_size}_ts{size_threshold}_mo{min_overlap}_mi{min_identity}_mm{max_mismatches}\""
    ]
   },
   {
@@ -209,7 +209,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "comb = get_combination_name(ass_method, conf, size_threshold, min_overlap, min_identity, max_mismatches)\n",
+    "comb = get_combination_name(ass_method, conf, kmer_size, size_threshold, min_overlap, min_identity, max_mismatches)\n",
     "\n",
     "print(comb)"
    ]
@@ -242,7 +242,7 @@
     "\n",
     "prep.create_directory(folder_outputs)\n",
     "\n",
-    "combination_folder_out = os.path.join(folder_outputs, f\"comb_{ass_method}_c{conf}_ks{kmer_size}_ts{size_threshold}_mo{min_overlap}_mi{min_identity}_mm{max_mismatches}\")\n",
+    "combination_folder_out = os.path.join(folder_outputs, comb)\n",
     "\n",
     "prep.create_subdirectories_outputs(combination_folder_out)"
    ]
@@ -785,7 +785,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "assembly",
+   "display_name": "instanexus",
    "language": "python",
    "name": "python3"
   },
@@ -799,7 +799,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.9.21"
   }
  },
  "nbformat": 4,

--- a/notebooks/greedy_workflow.ipynb
+++ b/notebooks/greedy_workflow.ipynb
@@ -241,7 +241,7 @@
     "\n",
     "prep.create_directory(folder_outputs)\n",
     "\n",
-    "combination_folder_out = os.path.join(folder_outputs, f\"comb_{ass_method}_c{conf}_ts{size_threshold}_mo{min_overlap}_mi{min_identity}_mm{max_mismatches}\")\n",
+    "combination_folder_out = os.path.join(folder_outputs, comb)\n",
     "\n",
     "prep.create_subdirectories_outputs(combination_folder_out)\n"
    ]
@@ -718,7 +718,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.23"
+   "version": "3.9.21"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #3 by setting `kmer_size` in the function `get_combination_name`