### PR TITLE
:art: add tags for documentation and dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,22 @@ classifiers = [
   "Operating System :: OS Independent"
 ]
 
+[project.optional-dependencies]
+# Optional dependencies to locally build the documentation, also used for 
+# readthedocs.
+docs = [
+  "sphinx",
+  "sphinx-book-theme",
+  "myst-nb",
+  "ipywidgets",
+  "sphinx-new-tab-link!=0.2.2",
+  "jupytext",
+  "sphinx-copybutton",
+]
+
+# local development options
+dev = ["black[jupyter]", "ruff", "pytest", "isort", "jupytext"]
+
 [project.urls]
 Homepage = "https://github.com/Multiomics-Analytics-Group/InstaNexus"
 Issues = "https://github.com/Multiomics-Analytics-Group/InstaNexus/issues"


### PR DESCRIPTION
Allows to install additional dependencies e.g. 

```bash
pip install ".[dev]"
pip install ".[docs]"
pip install ".[docs,dev]"
```