### PR TITLE
ci: add PyPI publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,67 @@
+# Publish instanexus to PyPI when a GitHub release is created.
+#
+# HOW IT WORKS
+# 1. A maintainer creates a new GitHub Release (via the web UI or gh CLI).
+# 2. This workflow triggers on the "release published" event.
+# 3. It checks out the code, builds an sdist + wheel with `python -m build`,
+#    and uploads both to PyPI using the PYPI_API_TOKEN secret.
+#
+# HOW TO TRIGGER
+# Option A — GitHub web UI:
+#   1. Go to https://github.com/Multiomics-Analytics-Group/InstaNexus/releases/new
+#   2. Create a new tag matching the version in pyproject.toml (e.g. v0.2.1)
+#   3. Fill in release title and notes, then click "Publish release"
+#   4. The workflow starts automatically.
+#
+# Option B — GitHub CLI:
+#   gh release create v0.2.1 --title "v0.2.1" --notes "Release notes here"
+#
+# Option C — Manual dispatch (for testing):
+#   Go to Actions → "Publish to PyPI" → "Run workflow", or:
+#   gh workflow run python-publish.yml
+#
+# PREREQUISITES
+# - A PyPI API token must be stored as a repository secret named PYPI_API_TOKEN.
+#   To create one: https://pypi.org/manage/account/token/
+#   Then add it at: Settings → Secrets and variables → Actions → New repository secret
+#
+# - The version in pyproject.toml must match the release tag (without the "v" prefix).
+#   For example, tag "v0.2.1" should correspond to version = "0.2.1" in pyproject.toml.
+#   PyPI will reject uploads if the version already exists.
+
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: "pip"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow (`.github/workflows/python-publish.yml`) that automatically builds and publishes the `instanexus` package to PyPI when a new GitHub Release is created. Modeled on the [InstaNovo publish workflow](https://github.com/instadeepai/InstaNovo/blob/main/.github/workflows/python-publish.yml).

## How it works

1. A maintainer creates a new GitHub Release (via the web UI or `gh` CLI)
2. The workflow triggers on the `release: published` event
3. It builds an sdist + wheel with `python -m build` and uploads to PyPI

## How to trigger

**Option A — GitHub web UI:**
1. Go to [Releases → New](https://github.com/Multiomics-Analytics-Group/InstaNexus/releases/new)
2. Create a new tag matching the version in `pyproject.toml` (e.g. `v0.2.1`)
3. Fill in release title and notes, click "Publish release"

**Option B — GitHub CLI:**
```bash
gh release create v0.2.1 --title "v0.2.1" --notes "Release notes here"
```

**Option C — Manual dispatch (for testing):**
```bash
gh workflow run python-publish.yml
```

## Prerequisites

A PyPI API token must be stored as a repository secret named `PYPI_API_TOKEN`:
1. Create a token at https://pypi.org/manage/account/token/
2. Add it at Settings → Secrets and variables → Actions → New repository secret

The version in `pyproject.toml` must match the release tag (without the `v` prefix). PyPI rejects duplicate version uploads.

## Test plan

- [ ] Verify the workflow file is valid (GitHub will show a syntax error on the Actions tab if not)
- [ ] Add the `PYPI_API_TOKEN` secret to the repo
- [ ] Test with manual dispatch (`gh workflow run python-publish.yml`) or create a test release
- [ ] Verify the package appears on https://pypi.org/project/instanexus/