### PR TITLE
fix: use absolute URLs for README images (fixes PyPI rendering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/source/assets/instanexus_logo 2.svg" width="600" alt="InstaNexus logo">
+  <img src="https://raw.githubusercontent.com/Multiomics-Analytics-Group/InstaNexus/main/docs/source/assets/instanexus_logo%202.svg" width="600" alt="InstaNexus logo">
 </p>
 
 <p align="center"><em>A de novo protein sequencing workflow</em></p>
@@ -52,7 +52,7 @@ This pipeline enables robust reconstruction of critical protein regions, advanci
 ## Workflow Diagram
 
 <p align="center">
-  <img src="images/instanexus_panel.png" width="900" alt="InstaNexus Workflow">
+  <img src="https://raw.githubusercontent.com/Multiomics-Analytics-Group/InstaNexus/main/docs/source/assets/instanexus_panel.png" width="900" alt="InstaNexus Workflow">
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Fixes #9 — images in the README don't render on PyPI because PyPI cannot resolve relative paths.

Two changes:
- **Logo** (`instanexus_logo 2.svg`): changed from relative `docs/source/assets/...` to absolute `raw.githubusercontent.com/...` URL
- **Workflow diagram** (`instanexus_panel.png`): was pointing to non-existent `images/instanexus_panel.png` — fixed to the actual location at `docs/source/assets/instanexus_panel.png` using an absolute URL

After merging, a new PyPI release is needed for the fix to appear on the [PyPI project page](https://pypi.org/project/instanexus/).

## Test plan

- [ ] After merge + release, verify images appear on https://pypi.org/project/instanexus/