### PR TITLE
feat: make demo notebooks reproducible in Codespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ figures/
 benchmark/
 logs/
 work/
+exercise2_work/
 examples/outputs/
 docs/build/
 demo/output_demo_nb1

--- a/demo/02_instanexus_nanobody_solved.ipynb
+++ b/demo/02_instanexus_nanobody_solved.ipynb
@@ -1,0 +1,761 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cover",
+   "metadata": {},
+   "source": [
+    "# Exercise 2 — Inspect InstaNovo predictions & assemble nanobody nb6\n",
+    "\n",
+    "**27666 · June 2026 · Module 2**\n",
+    "\n",
+    "**Goal**: take real mass-spectrometry data from a nanobody experiment, look at what InstaNovo predicted at the peptide level, then reconstruct the full nanobody sequence using a **greedy assembly algorithm** we'll implement inline.\n",
+    "\n",
+    "**Data**: `NB6.csv` — InstaNovo predictions on a nanobody (**nb6**) digested by 9 different proteases (Trypsin, Chymotrypsin, GluC, Elastase, ProteinaseK, Thermolysin, Papain, Krakatoa, Vesuvius) and measured by LC-MS/MS. Fetched via `wget` from the course repo — no manual upload required.\n",
+    "\n",
+    "**Algorithm**: port of the greedy mode of [InstaNexus](https://github.com/Multiomics-Analytics-Group/InstaNexus). The full InstaNexus pipeline also runs MMseqs2 clustering + Clustal Omega alignment + logomaker consensus. We keep just the greedy scaffolding core and discuss the trade-offs at the end.\n",
+    "\n",
+    "**Runtime**: ~5 min on free Colab. No native binaries, no heavy installs.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "attribution",
+   "metadata": {},
+   "source": [
+    "## Attribution\n",
+    "\n",
+    "- **InstaNovo** (de novo peptide sequencing): Eloff K.\\*, Kalogeropoulos K.\\* et al. *Nat Mach Intell* 7, 565–579 (2025).\n",
+    "- **InstaNexus** (assembly pipeline whose greedy mode we re-implement): Reverenna M. et al. *Mol Cell Proteomics* 25:4 (2026).\n",
+    "  Greedy algorithm adapted from `instanexus/assembly.py` (MIT licence).\n",
+    "- **Nanobody nb6 reference sequence**: from `InstaNexus-main/json/sample_metadata.json` (DTU Biosustain / Bioengineering).\n",
+    "- **Raw MS data**: DTU Bioengineering Proteomics Core Facility, 2025.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec1-md",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "\n",
+    "Just plain Python this time. No native binaries, no large packages.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess, sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "if Path('/content').exists():\n",
+    "    # Google Colab: install with pinned pandas compatible with Colab\n",
+    "    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q',\n",
+    "                           'pandas==2.2.2', 'biopython', 'matplotlib', 'seaborn', 'tqdm'])\n",
+    "    # NOTE: if pandas was already imported before this cell, restart the runtime\n",
+    "    # (Runtime → Restart session) and re-run from the top.\n",
+    "# Codespace / local dev: packages already installed via `uv sync --all-extras`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "sns.set_context('notebook')\n",
+    "WORK = Path('/content/27666_exercise2') if Path('/content').exists() else Path('exercise2_work')\n",
+    "WORK.mkdir(exist_ok=True)\n",
+    "print(f'working dir: {WORK}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec2-md",
+   "metadata": {},
+   "source": [
+    "## 2. Get the data\n",
+    "\n",
+    "`NB6.csv` lives in `Day_5/morning/data/` on the course repo. We download it via `wget` so students don't need to upload anything manually.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "get-data",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "SAMPLE_NAME = 'nb6'\n",
+    "NB_URL = 'https://raw.githubusercontent.com/DigBioLab/27666_Protein_Design/main/Day_5/morning/data/NB6.csv'\n",
+    "NB_PATH = WORK / f'{SAMPLE_NAME}.csv'\n",
+    "\n",
+    "if not NB_PATH.exists():\n",
+    "    print(f'Downloading {NB_URL} ...')\n",
+    "    urllib.request.urlretrieve(NB_URL, NB_PATH)\n",
+    "\n",
+    "assert NB_PATH.exists() and NB_PATH.stat().st_size > 1_000_000, (\n",
+    "    f'{NB_PATH} missing or suspiciously small — check the URL.'\n",
+    ")\n",
+    "\n",
+    "df = pd.read_csv(NB_PATH)\n",
+    "print(f'sample: {SAMPLE_NAME}   file: {NB_PATH}   rows: {len(df):,}')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec3-md",
+   "metadata": {},
+   "source": [
+    "## 3. Inspect the predictions\n",
+    "\n",
+    "Columns:\n",
+    "- `experiment_name` — encodes the protease used in that run\n",
+    "- `scan_number` — index of the MS/MS scan\n",
+    "- `preds` — predicted peptide sequence (empty if InstaNovo had no confident prediction)\n",
+    "- `log_probs` — InstaNovo's log-probability of the prediction (sentinel `-1.0` means \"no prediction\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nb-ref",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reference sequence of nb6 (from sample_metadata.json). Defined here so the\n",
+    "# pre-assembly coverage cell below can use it.\n",
+    "NB_REF = ('QVQLQESGGGLVQPGGSLRLSCTASLNIFSINAMGWYRQAPGKQRELVAAITSGGSTNYADSVKGRFTISRDNAKSTVY'\n",
+    "          'LQMNSLKPEDTAVYYCHAEGPFNIATKEQYDYWGQGTQVTVSSAAADYKDHDGDYKDHDIDYKDDDDKGAAHHHHHH')\n",
+    "print(f'reference {SAMPLE_NAME}: {len(NB_REF)} aa')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "parse-protease",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parse the protease out of the experiment name\n",
+    "def protease_of(name: str) -> str:\n",
+    "    m = re.search(r'Nanobodies_([A-Za-z]+)_\\d+ng', name)\n",
+    "    return m.group(1) if m else 'unknown'\n",
+    "\n",
+    "df['protease'] = df['experiment_name'].apply(protease_of)\n",
+    "df['has_pred'] = df['preds'].notna() & (df['preds'] != '')\n",
+    "\n",
+    "summary = (df.groupby('protease')\n",
+    "             .agg(scans=('scan_number', 'count'),\n",
+    "                  with_pred=('has_pred', 'sum'),\n",
+    "                  hit_rate=('has_pred', 'mean'))\n",
+    "             .sort_values('scans', ascending=False))\n",
+    "print(summary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "logprob-dist",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# log_probs distribution for real predictions only\n",
+    "real = df[df['has_pred'] & (df['log_probs'] > -1)].copy()\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 4.5))\n",
+    "sns.histplot(real['log_probs'], bins=60, ax=axes[0], color='steelblue')\n",
+    "axes[0].set(title='InstaNovo log-prob distribution (predicted peptides)',\n",
+    "             xlabel='log P', ylabel='# peptides')\n",
+    "\n",
+    "sns.boxplot(data=real, x='protease', y='log_probs', ax=axes[1],\n",
+    "             order=summary.index.tolist(), color='lightsteelblue')\n",
+    "axes[1].set(title='Raw confidence by protease', xlabel='', ylabel='log P')\n",
+    "axes[1].tick_params(axis='x', rotation=35)\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "logprob-md",
+   "metadata": {},
+   "source": [
+    "**Observations to make**:\n",
+    "- A large fraction of scans have **no prediction** — that's normal: not every MS/MS scan is fragmenting a peptide cleanly.\n",
+    "- Confidence varies between proteases. Why? (Hint: tryptic peptides are over-represented in InstaNovo's training data.)\n",
+    "- The `log_probs` are *raw model log-likelihoods*, not calibrated probabilities. This is the FDR problem we mentioned on Module 2 slide 15.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec4-md",
+   "metadata": {},
+   "source": [
+    "## 4. Pre-assembly checks\n",
+    "\n",
+    "Before running anything, get a feel for the data:\n",
+    "- **Per-residue confidence** on a 0–1 scale (instead of raw `log_probs`).\n",
+    "- **Peptide length** by protease.\n",
+    "- **Peptide overlap** between proteases (Jaccard).\n",
+    "- **Pre-assembly coverage** by exact substring match against the nb6 reference (the assembly-free baseline).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-conf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# log_probs is the SUM of per-position log-probabilities. To compare peptides of\n",
+    "# different lengths, take the geometric mean per residue: exp(log_prob / L).\n",
+    "real['pep_len']     = real['preds'].str.len()\n",
+    "real['conf_per_aa'] = np.exp(real['log_probs'] / real['pep_len'])\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(13, 4.5))\n",
+    "sns.histplot(real['conf_per_aa'], bins=60, ax=axes[0], color='steelblue')\n",
+    "axes[0].axvline(0.8, color='red', linestyle='--', label='cutoff 0.8')\n",
+    "axes[0].set(title='Per-residue confidence (0–1 scale)',\n",
+    "            xlabel='exp(log_p / L)', ylabel='# peptides')\n",
+    "axes[0].legend()\n",
+    "\n",
+    "sns.boxplot(data=real, x='protease', y='conf_per_aa', ax=axes[1],\n",
+    "            order=summary.index.tolist(), color='lightsteelblue')\n",
+    "axes[1].axhline(0.8, color='red', linestyle='--')\n",
+    "axes[1].set(title='Per-residue confidence by protease', xlabel='', ylabel='exp(log_p / L)')\n",
+    "axes[1].tick_params(axis='x', rotation=35)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "n_hi = (real['conf_per_aa'] > 0.8).sum()\n",
+    "print(f'Peptides with per-residue conf > 0.8: {n_hi} ({n_hi/len(real):.1%})')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-len",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "sns.boxplot(data=real, x='protease', y='pep_len', ax=ax,\n",
+    "            order=summary.index.tolist(), color='peachpuff')\n",
+    "ax.set(title='Peptide length distribution by protease', xlabel='', ylabel='peptide length (aa)')\n",
+    "ax.tick_params(axis='x', rotation=35)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "print('Median peptide length per protease:')\n",
+    "print(real.groupby('protease')['pep_len'].median().sort_values(ascending=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-overlap",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Jaccard similarity of peptide sets between protease pairs.\n",
+    "# We WANT low off-diagonal Jaccard — different proteases should be complementary.\n",
+    "peps_by_protease = {p: set(real[real.protease == p].preds.unique())\n",
+    "                    for p in real.protease.unique()}\n",
+    "ps = sorted(peps_by_protease.keys())\n",
+    "n = len(ps)\n",
+    "J = np.zeros((n, n))\n",
+    "for i, p1 in enumerate(ps):\n",
+    "    for j, p2 in enumerate(ps):\n",
+    "        a, b = peps_by_protease[p1], peps_by_protease[p2]\n",
+    "        J[i, j] = len(a & b) / max(1, len(a | b))\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6.5, 5.5))\n",
+    "sns.heatmap(J, annot=True, fmt='.2f', cmap='Blues',\n",
+    "            xticklabels=ps, yticklabels=ps, ax=ax,\n",
+    "            cbar_kws={'label': 'Jaccard similarity'})\n",
+    "ax.set_title('Peptide overlap between proteases')\n",
+    "plt.xticks(rotation=35); plt.tight_layout(); plt.show()\n",
+    "\n",
+    "union = set().union(*peps_by_protease.values())\n",
+    "print(f'\\nTotal unique peptides across all proteases: {len(union)}')\n",
+    "for p in ps:\n",
+    "    print(f'  {p:14s}: {len(peps_by_protease[p]):4d} unique peptides')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-cov",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick coverage estimate: for each high-confidence peptide, find all exact substring\n",
+    "# matches against the nb6 reference. This is the assembly-free LOWER BOUND.\n",
+    "HIGH_CONF = real[real['conf_per_aa'] > 0.8]\n",
+    "covered_pre = np.zeros(len(NB_REF), dtype=int)\n",
+    "matched_peptides = 0\n",
+    "for pep in HIGH_CONF['preds'].unique():\n",
+    "    start, found = 0, False\n",
+    "    while True:\n",
+    "        idx = NB_REF.find(pep, start)\n",
+    "        if idx < 0: break\n",
+    "        covered_pre[idx:idx + len(pep)] += 1\n",
+    "        start = idx + 1\n",
+    "        found = True\n",
+    "    if found:\n",
+    "        matched_peptides += 1\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 3))\n",
+    "ax.bar(range(len(NB_REF)), covered_pre, width=1.0, color='steelblue')\n",
+    "ax.set(xlabel=f'position in {SAMPLE_NAME} reference', ylabel='# peptide matches',\n",
+    "       title='Pre-assembly coverage by exact-match high-confidence peptides')\n",
+    "ax.spines[['top', 'right']].set_visible(False)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "frac = (covered_pre > 0).mean()\n",
+    "n_uniq_high = HIGH_CONF['preds'].nunique()\n",
+    "print(f'High-confidence unique peptides: {n_uniq_high}')\n",
+    "print(f'  ...matching the {SAMPLE_NAME} reference exactly: {matched_peptides}')\n",
+    "print(f'Reference positions covered by ≥1 high-confidence peptide: '\n",
+    "      f'{(covered_pre > 0).sum()} / {len(NB_REF)} ({frac:.1%})')\n",
+    "print('\\nThis is a LOWER BOUND — assembly will chain peptides via overlapping ends.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "preasm-md",
+   "metadata": {},
+   "source": [
+    "**What to look at**:\n",
+    "- **Per-residue confidence**: how many peptides survive a 0.8 cutoff? If very few, we should relax it.\n",
+    "- **Peptide length**: Trypsin / LysC give short, regular peptides; ProteinaseK / Elastase give a wider distribution. Mixing proteases is how we cover regions that one protease misses.\n",
+    "- **Overlap heatmap**: high off-diagonal Jaccard means two proteases are redundant. We *want* low off-diagonal values so the panel covers more of the protein.\n",
+    "- **Pre-assembly coverage**: rough preview of where assembly will succeed. If a region is dark here, the greedy chain has very little chance to recover it — and CDR3 is almost always the dark spot.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5-md",
+   "metadata": {},
+   "source": [
+    "## 5. The greedy assembly algorithm\n",
+    "\n",
+    "We re-implement the **greedy mode** of [InstaNexus](https://github.com/Multiomics-Analytics-Group/InstaNexus) inline so the notebook has no native-binary dependency. The full pipeline also runs MMseqs2 clustering + Clustal Omega alignment + a logomaker consensus step on top of greedy contigs — we skip those here to keep the moving parts small. Discussion at the end covers when those extra steps actually help.\n",
+    "\n",
+    "**The core idea** (greedy assembly of a set of peptides):\n",
+    "1. For every pair of peptides (A, B), find the **largest suffix-of-A == prefix-of-B** of length ≥ `min_overlap`.\n",
+    "2. Sort all such overlaps by length, descending.\n",
+    "3. Greedily merge the highest-scoring pair first; each peptide can be used at most once per round.\n",
+    "4. Repeat until no more merges are possible (or until we hit `MAX_ITERATIONS`).\n",
+    "\n",
+    "After per-protease assembly we get contigs. We then **scaffold** by pooling contigs across proteases and re-running the same greedy logic with substring deduplication between rounds.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "asm-helpers-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_sliding_overlaps(sequences, min_overlap):\n",
+    "    '''All pairs (i, j) with their largest suffix-of-i == prefix-of-j overlap (≥ min_overlap).'''\n",
+    "    overlaps = []\n",
+    "    for i, seq_a in enumerate(sequences):\n",
+    "        for j, seq_b in enumerate(sequences):\n",
+    "            if i == j:\n",
+    "                continue\n",
+    "            max_search = min(len(seq_a), len(seq_b))\n",
+    "            for length in range(max_search, min_overlap - 1, -1):\n",
+    "                if seq_a[-length:] == seq_b[:length]:\n",
+    "                    overlaps.append((i, j, length))\n",
+    "                    break   # only the LARGEST overlap per pair\n",
+    "    return overlaps\n",
+    "\n",
+    "\n",
+    "def merge_with_overhang(seq_a, seq_b, overlap_len):\n",
+    "    '''Merge a and b given suffix(a) == prefix(b). Handles substring containment.'''\n",
+    "    if seq_a in seq_b:\n",
+    "        return seq_b\n",
+    "    if seq_b in seq_a:\n",
+    "        return seq_a\n",
+    "    for i in range(len(seq_a) - overlap_len + 1):\n",
+    "        suffix = seq_a[i:]\n",
+    "        if seq_b.startswith(suffix):\n",
+    "            return seq_a[:i] + seq_b\n",
+    "    return seq_a + seq_b[overlap_len:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "asm-helpers-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def assemble_contigs_greedy(peptides, min_overlap, max_iterations=50):\n",
+    "    '''Iterative greedy merging until convergence or max_iterations.'''\n",
+    "    contigs = list(peptides)\n",
+    "    for _ in range(max_iterations):\n",
+    "        overlaps = find_sliding_overlaps(contigs, min_overlap)\n",
+    "        if not overlaps:\n",
+    "            break\n",
+    "        overlaps.sort(key=lambda x: x[2], reverse=True)\n",
+    "        new_contigs = []\n",
+    "        used = set()\n",
+    "        for i, j, ovl in overlaps:\n",
+    "            if i in used or j in used:\n",
+    "                continue\n",
+    "            new_contigs.append(merge_with_overhang(contigs[i], contigs[j], ovl))\n",
+    "            used.update([i, j])\n",
+    "        if not new_contigs:\n",
+    "            break\n",
+    "        remaining = [c for k, c in enumerate(contigs) if k not in used]\n",
+    "        contigs = new_contigs + remaining\n",
+    "    return contigs\n",
+    "\n",
+    "\n",
+    "def remove_substring_contigs(contigs):\n",
+    "    '''Drop contigs that are substrings of longer contigs.'''\n",
+    "    contigs = sorted(set(contigs), key=len, reverse=True)\n",
+    "    keep = []\n",
+    "    for c in contigs:\n",
+    "        if not any(c != c2 and c in c2 for c2 in keep):\n",
+    "            keep.append(c)\n",
+    "    return keep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "asm-helpers-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scaffold_iterative_greedy(contigs, min_overlap, size_threshold, max_rounds=2):\n",
+    "    '''Iteratively scaffold a pool of contigs into a smaller set of longer scaffolds.'''\n",
+    "    def clean(seqs):\n",
+    "        seqs = list(set(seqs))\n",
+    "        seqs = [s for s in seqs if len(s) > size_threshold]\n",
+    "        return sorted(seqs, key=len, reverse=True)\n",
+    "\n",
+    "    current = clean(contigs)\n",
+    "    for round_idx in range(max_rounds):\n",
+    "        overlaps = find_sliding_overlaps(current, min_overlap)\n",
+    "        combined = [merge_with_overhang(current[i], current[j], ovl)\n",
+    "                    for i, j, ovl in overlaps]\n",
+    "        next_round = clean(remove_substring_contigs(combined + current))\n",
+    "        if len(next_round) == len(current):\n",
+    "            break\n",
+    "        current = next_round\n",
+    "    return current"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec6-md",
+   "metadata": {},
+   "source": [
+    "## 6. Filter peptides and run the assembly on nb6\n",
+    "\n",
+    "**Pipeline**: filter by confidence → drop contaminants → per-protease greedy assembly → cross-protease scaffolding.\n",
+    "\n",
+    "We use a small **inline contaminants set** — trypsin self-digest, common keratin, BSA — typical lab MS contaminants. Any predicted peptide that is a substring of a contaminant sequence is discarded.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "filter-peps",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hyperparameters — try changing these and re-running!\n",
+    "CONF_CUTOFF    = 0.8    # per-residue confidence cutoff for keeping a peptide\n",
+    "MIN_OVERLAP    = 3      # minimum AA overlap to chain two peptides\n",
+    "SIZE_THRESHOLD = 8      # discard contigs shorter than this in scaffolding\n",
+    "\n",
+    "CONTAMINANTS = [\n",
+    "    # Trypsin self-digest fragment\n",
+    "    'VVGGYTCAANSIPYQVSLNSGSHFCGGSLINSQWVVSAAHCYKSRIQVRLGEHNIDVLEGNEQFINAAKIIKHPNFDR',\n",
+    "    # Human keratin K1 fragment\n",
+    "    'MSRQFSSRSGYRSGGGFSSGSAGIINYQRRTTSSSTRRSGGGGGRFSSCGGGGGSFGAGGGFGSRSLVNLGGSKSISIS',\n",
+    "    # BSA fragment\n",
+    "    'MKWVTFISLLLLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPFDEHVKLVNELTEFAKTCVADESHAGCEK',\n",
+    "]\n",
+    "\n",
+    "def is_contaminant(peptide):\n",
+    "    return any(peptide in c for c in CONTAMINANTS)\n",
+    "\n",
+    "filtered = real[real['conf_per_aa'] > CONF_CUTOFF].copy()\n",
+    "n_before = len(filtered)\n",
+    "filtered = filtered[~filtered['preds'].apply(is_contaminant)]\n",
+    "n_after = len(filtered)\n",
+    "print(f'High-confidence peptides       : {n_before}')\n",
+    "print(f'... after contaminant removal  : {n_after}')\n",
+    "print(f'Discarded as contaminants      : {n_before - n_after}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "per-protease-asm",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Per-protease greedy assembly\n",
+    "contigs_by_protease = {}\n",
+    "for protease, group in tqdm(filtered.groupby('protease'), desc='greedy per protease'):\n",
+    "    peps = group['preds'].unique().tolist()\n",
+    "    contigs = assemble_contigs_greedy(peps, min_overlap=MIN_OVERLAP)\n",
+    "    contigs = remove_substring_contigs(contigs)\n",
+    "    contigs_by_protease[protease] = contigs\n",
+    "\n",
+    "print('\\nContigs per protease (top 3 by length shown):')\n",
+    "for p, cs in contigs_by_protease.items():\n",
+    "    longest = sorted(cs, key=len, reverse=True)[:3]\n",
+    "    print(f'  {p:14s}: {len(cs):3d} contigs, longest={len(longest[0]) if longest else 0} aa')\n",
+    "    for c in longest:\n",
+    "        print(f'      ({len(c):3d}) {c[:80]}{\"…\" if len(c) > 80 else \"\"}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cross-protease-scaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pool all contigs across proteases → scaffold iteratively\n",
+    "all_contigs = [c for cs in contigs_by_protease.values() for c in cs]\n",
+    "print(f'Pooled contigs (all proteases): {len(all_contigs)}')\n",
+    "\n",
+    "scaffolds = scaffold_iterative_greedy(all_contigs,\n",
+    "                                       min_overlap=MIN_OVERLAP,\n",
+    "                                       size_threshold=SIZE_THRESHOLD)\n",
+    "\n",
+    "print(f'\\nFinal scaffolds: {len(scaffolds)}')\n",
+    "for i, s in enumerate(sorted(scaffolds, key=len, reverse=True)[:10]):\n",
+    "    print(f'  #{i+1}  ({len(s):3d} aa)  {s[:90]}{\"…\" if len(s) > 90 else \"\"}')\n",
+    "\n",
+    "print(f'\\n✓ Greedy assembly complete — {len(scaffolds)} scaffolds, longest {max(len(s) for s in scaffolds) if scaffolds else 0} aa.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec7-md",
+   "metadata": {},
+   "source": [
+    "## 7. Map scaffolds onto the nb6 reference\n",
+    "\n",
+    "Pairwise-align every scaffold against the known nb6 sequence, then plot a **coverage track** with the canonical VHH CDR1, CDR2 and CDR3 regions highlighted.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cov-plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Bio import pairwise2\n",
+    "\n",
+    "# Approximate CDR boundaries for VHH (Kabat-ish numbering applied to the framework).\n",
+    "# For production work use ANARCI or IMGT.\n",
+    "CDR1 = (25, 35)\n",
+    "CDR2 = (49, 58)\n",
+    "WGQ  = NB_REF.find('WGQGTQ')\n",
+    "CDR3 = (95, WGQ if WGQ > 0 else 115)\n",
+    "\n",
+    "def coverage_mask(seqs):\n",
+    "    covered = np.zeros(len(NB_REF), dtype=int)\n",
+    "    for q in seqs:\n",
+    "        if not q: continue\n",
+    "        aln = pairwise2.align.localxs(NB_REF, q, -2, -1, one_alignment_only=True)\n",
+    "        if not aln: continue\n",
+    "        target_aln, query_aln, _, start, end = aln[0]\n",
+    "        ti = 0\n",
+    "        for tc, qc in zip(target_aln, query_aln):\n",
+    "            if tc != '-':\n",
+    "                if qc != '-' and ti >= start and ti < end:\n",
+    "                    covered[ti] += 1\n",
+    "                ti += 1\n",
+    "    return covered\n",
+    "\n",
+    "scaffold_cov = coverage_mask(scaffolds)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 3.5))\n",
+    "ax.bar(range(len(NB_REF)), scaffold_cov, width=1.0, color='#1f77b4')\n",
+    "ax.set_ylabel('# scaffolds covering')\n",
+    "ymax = max(1, ax.get_ylim()[1])\n",
+    "for cdr, name in zip([CDR1, CDR2, CDR3], ['CDR1', 'CDR2', 'CDR3']):\n",
+    "    ax.axvspan(cdr[0], cdr[1], color='red', alpha=0.12)\n",
+    "    ax.text((cdr[0]+cdr[1])/2, ymax*0.9, name, ha='center', fontsize=9, color='darkred')\n",
+    "ax.spines[['top','right']].set_visible(False)\n",
+    "ax.set_xlabel(f'position in {SAMPLE_NAME} reference')\n",
+    "ax.set_title(f'Greedy-assembly scaffold coverage of {SAMPLE_NAME}')\n",
+    "plt.tight_layout(); plt.savefig(WORK/f'{SAMPLE_NAME}_coverage.png', dpi=150, bbox_inches='tight'); plt.show()\n",
+    "\n",
+    "print(f'Reference length: {len(NB_REF)} aa')\n",
+    "print(f'Positions covered by ≥1 scaffold: {int((scaffold_cov > 0).sum())} ({(scaffold_cov > 0).mean():.1%})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cov-md",
+   "metadata": {},
+   "source": [
+    "**Reading the track**:\n",
+    "- Tall bars = high redundancy at that position. Good.\n",
+    "- Dark gaps in CDR3 (the rightmost red band) are expected — that's the hypervariable loop.\n",
+    "- Dark gaps OUTSIDE the CDRs are bad: usually missed cleavage sites, low-signal protease, or contamination.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec8-md",
+   "metadata": {},
+   "source": [
+    "## 8. Best scaffold vs. reference — identity over the variable domain\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "best-scaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Bio.pairwise2 import format_alignment\n",
+    "\n",
+    "def best_pick(seqs):\n",
+    "    '''Return (seq, identity_over_VHH, alignment) of the scaffold with the highest\n",
+    "    identity to the nb6 variable domain (residues 0..WGQ).'''\n",
+    "    variable = NB_REF[:WGQ if WGQ > 0 else 120]\n",
+    "    best = ('', 0.0, None)\n",
+    "    for s in seqs:\n",
+    "        if not s: continue\n",
+    "        aln = pairwise2.align.globalxs(variable, s, -2, -1, one_alignment_only=True)\n",
+    "        if not aln: continue\n",
+    "        t, q, _, _, _ = aln[0]\n",
+    "        matches = sum(1 for a, b in zip(t, q) if a == b and a != '-')\n",
+    "        ident = matches / max(1, sum(1 for a in t if a != '-'))\n",
+    "        if ident > best[1]:\n",
+    "            best = (s, ident, aln[0])\n",
+    "    return best\n",
+    "\n",
+    "best_seq, best_ident, best_aln = best_pick(scaffolds)\n",
+    "print(f'Best scaffold identity to {SAMPLE_NAME} variable domain: {best_ident:.1%}')\n",
+    "print(f'Scaffold length: {len(best_seq)} aa\\n')\n",
+    "if best_aln:\n",
+    "    print(format_alignment(*best_aln, full_sequences=False)[:2400])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec9-md",
+   "metadata": {},
+   "source": [
+    "## 9. (Optional stretch) Close the loop with ESM-2\n",
+    "\n",
+    "From Module 1: take the best scaffold and the true reference, embed both with ESM-2, compare. If the assembly is mostly right outside CDR3, the embeddings should be very close.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "esm-closure",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import torch\n",
+    "    from transformers import AutoTokenizer, AutoModel\n",
+    "\n",
+    "    MODEL_NAME = 'facebook/esm2_t6_8M_UR50D'\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "    model = AutoModel.from_pretrained(MODEL_NAME).eval()\n",
+    "\n",
+    "    @torch.no_grad()\n",
+    "    def embed(seq):\n",
+    "        x = tokenizer(seq, return_tensors='pt')\n",
+    "        h = model(**x).last_hidden_state[0, 1:-1].mean(0).numpy()\n",
+    "        return h / np.linalg.norm(h)\n",
+    "\n",
+    "    ref_emb = embed(NB_REF)\n",
+    "    if best_seq:\n",
+    "        scaf_emb = embed(best_seq)\n",
+    "        cos = float(ref_emb @ scaf_emb)\n",
+    "        print(f'Cosine similarity of best scaffold to {SAMPLE_NAME} reference: {cos:.4f}')\n",
+    "        print('(1.0 = identical, 0.0 = orthogonal; expect 0.95+ on a successful assembly.)')\n",
+    "    else:\n",
+    "        print('No scaffold to compare.')\n",
+    "except Exception as e:\n",
+    "    print('Skipping ESM closure step:', e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "discussion-md",
+   "metadata": {},
+   "source": [
+    "## 10. Discussion prompts\n",
+    "\n",
+    "1. **Hyperparameter sweep**: try `CONF_CUTOFF ∈ {0.7, 0.8, 0.9}`, `MIN_OVERLAP ∈ {2, 3, 5}`, `SIZE_THRESHOLD ∈ {5, 8, 12}` and re-run from Section 6. Which combination maximises identity to the reference? Which produces the longest scaffold?\n",
+    "2. **Where did the assembly fail?** Look at the coverage track. Is CDR3 the worst region? Why is it so hard *both* for MS de novo *and* for MSA-based methods (Module 1 slide 10)?\n",
+    "3. **Which protease pulled its weight?** Look back at the per-protease contig list (Section 6). Which protease contributed the longest contigs? Which one underperformed? Could you have spent your beam time better?\n",
+    "4. **No reference?** In a real nanobody discovery campaign you don't *have* the reference. How would you judge assembly quality without one? (Hint: longest scaffold length, total covered residues, embedding plausibility from Module 1.)\n",
+    "5. **Pre-assembly checks (Section 4) vs. post-assembly result**: did the greedy chain close gaps that the exact-match preview missed? Where?\n",
+    "6. **What did we skip?** The full InstaNexus pipeline runs MMseqs2 clustering, Clustal Omega alignment and a logomaker consensus on top of greedy contigs. When would those extra steps help? Hint: multiple competing scaffolds covering the same region.\n",
+    "\n",
+    "Bring one observation to the closing discussion.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "end",
+   "metadata": {},
+   "source": [
+    "## End of Exercise 2 — end of the 4-hour module\n",
+    "\n",
+    "You have:\n",
+    "- Run a **foundation model** (ESM-2) on protein sequences and used the embeddings for visualisation, classification, zero-shot variant scoring, and a regression task (Exercise 1).\n",
+    "- **Inspected real InstaNovo predictions** on a nanobody MS dataset — log-prob distribution, per-residue confidence on a 0–1 scale, peptide length by protease, inter-protease Jaccard overlap, and a quick pre-assembly coverage check.\n",
+    "- **Implemented and ran greedy assembly** inline — per-protease contigs followed by cross-protease scaffolding — and seen how a ~100-line algorithm reconstructs much of a 153-aa nanobody from messy de novo peptide predictions.\n",
+    "- Compared the assembled scaffolds against the **known reference** and visualised coverage with CDR1/2/3 highlighted.\n",
+    "- **Closed the loop** by re-embedding the best scaffold with ESM-2 and measuring cosine similarity to the reference.\n",
+    "\n",
+    "Same paradigm — foundation model pretraining → embeddings or scoring → downstream task — across three data modalities (protein sequences, mass spectra, and your own assembly output). That is the foundation-model paradigm in biology.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/demo/02_instanexus_nanobody_student.ipynb
+++ b/demo/02_instanexus_nanobody_student.ipynb
@@ -1,0 +1,782 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cover",
+   "metadata": {},
+   "source": [
+    "# Exercise 2 — Inspect InstaNovo predictions & assemble nanobody nb6\n",
+    "\n",
+    "**27666 · June 2026 · Module 2**\n",
+    "\n",
+    "**Goal**: take real mass-spectrometry data from a nanobody experiment, look at what InstaNovo predicted at the peptide level, then reconstruct the full nanobody sequence using a **greedy assembly algorithm** we'll implement inline.\n",
+    "\n",
+    "**Data**: `NB6.csv` — InstaNovo predictions on a nanobody (**nb6**) digested by 9 different proteases (Trypsin, Chymotrypsin, GluC, Elastase, ProteinaseK, Thermolysin, Papain, Krakatoa, Vesuvius) and measured by LC-MS/MS. Fetched via `wget` from the course repo — no manual upload required.\n",
+    "\n",
+    "**Algorithm**: greedy mode of [InstaNexus](https://github.com/Multiomics-Analytics-Group/InstaNexus). The full InstaNexus pipeline also runs MMseqs2 clustering + Clustal Omega alignment + logomaker consensus. We keep just the greedy scaffolding core and discuss the trade-offs at the end.\n",
+    "\n",
+    "**Runtime**: ~5 min on free Colab. No native binaries, no heavy installs.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "student-intro",
+   "metadata": {},
+   "source": [
+    "## 🧑‍🎓 Student notebook — fill in the blanks!\n",
+    "\n",
+    "This notebook contains **8 `TODO_N` markers** where you need to write a small piece of code before the cell will run. Each `TODO` is a real design choice a researcher makes — not a trick. If you get stuck, the markdown above the cell and the hint in the comment usually contain the answer.\n",
+    "\n",
+    "**The blanks**:\n",
+    "\n",
+    "- `TODO_1` (Sec. 6) — per-residue confidence cutoff (`CONF_CUTOFF`).\n",
+    "- `TODO_2` (Sec. 6) — minimum peptide overlap (`MIN_OVERLAP`).\n",
+    "- `TODO_3` (Sec. 6) — minimum contig length for scaffolding (`SIZE_THRESHOLD`).\n",
+    "- `TODO_4` (Sec. 7) — CDR1 boundary positions in the nb6 reference.\n",
+    "- `TODO_5` (Sec. 7) — CDR3 start position and fallback end position.\n",
+    "- `TODO_6` (Sec. 7) — gap-open and gap-extend penalties for scaffold→reference alignment.\n",
+    "- `TODO_7` (Sec. 9) — L2 normalisation that turns dot product into cosine similarity.\n",
+    "- `TODO_8` (Sec. 5) — sort order in `remove_substring_contigs` so longer contigs come first.\n",
+    "\n",
+    "Cells run top-to-bottom. If a cell crashes with `SyntaxError` or `NameError`, check for an unfilled `____` or `___`. A `_solved` companion notebook exists — try to resist looking at it!\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "attribution",
+   "metadata": {},
+   "source": [
+    "## Attribution\n",
+    "\n",
+    "- **InstaNovo** (de novo peptide sequencing): Eloff K.\\*, Kalogeropoulos K.\\* et al. *Nat Mach Intell* 7, 565–579 (2025).\n",
+    "- **InstaNexus** (assembly pipeline whose greedy mode we re-implement): Reverenna M. et al. *Mol Cell Proteomics* 25:4 (2026).\n",
+    "  Greedy faithfully adapted from `instanexus/assembly.py` (MIT licence).\n",
+    "- **Nanobody nb6 reference sequence**: from `InstaNexus-main/json/sample_metadata.json` (DTU Biosustain / Bioengineering).\n",
+    "- **Raw MS data**: DTU Bioengineering Proteomics Core Facility, 2025.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec1-md",
+   "metadata": {},
+   "source": [
+    "## 1. Setup\n",
+    "\n",
+    "Just plain Python this time. No native binaries, no large packages.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess, sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "if Path('/content').exists():\n",
+    "    # Google Colab: install with pinned pandas compatible with Colab\n",
+    "    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q',\n",
+    "                           'pandas==2.2.2', 'biopython', 'matplotlib', 'seaborn', 'tqdm'])\n",
+    "    # NOTE: if pandas was already imported before this cell, restart the runtime\n",
+    "    # (Runtime → Restart session) and re-run from the top.\n",
+    "# Codespace / local dev: packages already installed via `uv sync --all-extras`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "from tqdm.auto import tqdm\n",
+    "\n",
+    "sns.set_context('notebook')\n",
+    "WORK = Path('/content/27666_exercise2') if Path('/content').exists() else Path('exercise2_work')\n",
+    "WORK.mkdir(exist_ok=True)\n",
+    "print(f'working dir: {WORK}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec2-md",
+   "metadata": {},
+   "source": [
+    "## 2. Get the data\n",
+    "\n",
+    "`NB6.csv` lives in `Day_5/morning/data/` on the course repo. We download it via `wget` so students don't need to upload anything manually.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "get-data",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "SAMPLE_NAME = 'nb6'\n",
+    "NB_URL = 'https://raw.githubusercontent.com/DigBioLab/27666_Protein_Design/main/Day_5/morning/data/NB6.csv'\n",
+    "NB_PATH = WORK / f'{SAMPLE_NAME}.csv'\n",
+    "\n",
+    "if not NB_PATH.exists():\n",
+    "    print(f'Downloading {NB_URL} ...')\n",
+    "    urllib.request.urlretrieve(NB_URL, NB_PATH)\n",
+    "\n",
+    "assert NB_PATH.exists() and NB_PATH.stat().st_size > 1_000_000, (\n",
+    "    f'{NB_PATH} missing or suspiciously small — check the URL.'\n",
+    ")\n",
+    "\n",
+    "df = pd.read_csv(NB_PATH)\n",
+    "print(f'sample: {SAMPLE_NAME}   file: {NB_PATH}   rows: {len(df):,}')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec3-md",
+   "metadata": {},
+   "source": [
+    "## 3. Inspect the predictions\n",
+    "\n",
+    "Columns:\n",
+    "- `experiment_name` — encodes the protease used in that run\n",
+    "- `scan_number` — index of the MS/MS scan\n",
+    "- `preds` — predicted peptide sequence (empty if InstaNovo had no confident prediction)\n",
+    "- `log_probs` — InstaNovo's log-probability of the prediction (sentinel `-1.0` means \"no prediction\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nb-ref",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reference sequence of nb6 (from sample_metadata.json). Defined here so the\n",
+    "# pre-assembly coverage cell below can use it.\n",
+    "NB_REF = ('QVQLQESGGGLVQPGGSLRLSCTASLNIFSINAMGWYRQAPGKQRELVAAITSGGSTNYADSVKGRFTISRDNAKSTVY'\n",
+    "          'LQMNSLKPEDTAVYYCHAEGPFNIATKEQYDYWGQGTQVTVSSAAADYKDHDGDYKDHDIDYKDDDDKGAAHHHHHH')\n",
+    "print(f'reference {SAMPLE_NAME}: {len(NB_REF)} aa')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "parse-protease",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parse the protease out of the experiment name\n",
+    "def protease_of(name: str) -> str:\n",
+    "    m = re.search(r'Nanobodies_([A-Za-z]+)_\\d+ng', name)\n",
+    "    return m.group(1) if m else 'unknown'\n",
+    "\n",
+    "df['protease'] = df['experiment_name'].apply(protease_of)\n",
+    "df['has_pred'] = df['preds'].notna() & (df['preds'] != '')\n",
+    "\n",
+    "summary = (df.groupby('protease')\n",
+    "             .agg(scans=('scan_number', 'count'),\n",
+    "                  with_pred=('has_pred', 'sum'),\n",
+    "                  hit_rate=('has_pred', 'mean'))\n",
+    "             .sort_values('scans', ascending=False))\n",
+    "print(summary)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "logprob-dist",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# log_probs distribution for real predictions only\n",
+    "real = df[df['has_pred'] & (df['log_probs'] > -1)].copy()\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 4.5))\n",
+    "sns.histplot(real['log_probs'], bins=60, ax=axes[0], color='steelblue')\n",
+    "axes[0].set(title='InstaNovo log-prob distribution (predicted peptides)',\n",
+    "             xlabel='log P', ylabel='# peptides')\n",
+    "\n",
+    "sns.boxplot(data=real, x='protease', y='log_probs', ax=axes[1],\n",
+    "             order=summary.index.tolist(), color='lightsteelblue')\n",
+    "axes[1].set(title='Raw confidence by protease', xlabel='', ylabel='log P')\n",
+    "axes[1].tick_params(axis='x', rotation=35)\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "logprob-md",
+   "metadata": {},
+   "source": [
+    "**Observations to make**:\n",
+    "- A large fraction of scans have **no prediction** — that's normal: not every MS/MS scan is fragmenting a peptide cleanly.\n",
+    "- Confidence varies between proteases. Why? (Hint: tryptic peptides are over-represented in InstaNovo's training data.)\n",
+    "- The `log_probs` are *raw model log-likelihoods*, not calibrated probabilities. This is the FDR problem we mentioned on Module 2 slide 15.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec4-md",
+   "metadata": {},
+   "source": [
+    "## 4. Pre-assembly checks\n",
+    "\n",
+    "Before running anything, get a feel for the data:\n",
+    "- **Per-residue confidence** on a 0–1 scale (instead of raw `log_probs`).\n",
+    "- **Peptide length** by protease.\n",
+    "- **Peptide overlap** between proteases (Jaccard).\n",
+    "- **Pre-assembly coverage** by exact substring match against the nb6 reference (the assembly-free baseline).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-conf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# log_probs is the SUM of per-position log-probabilities. To compare peptides of\n",
+    "# different lengths, take the geometric mean per residue: exp(log_prob / L).\n",
+    "real['pep_len']     = real['preds'].str.len()\n",
+    "real['conf_per_aa'] = np.exp(real['log_probs'] / real['pep_len'])\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(13, 4.5))\n",
+    "sns.histplot(real['conf_per_aa'], bins=60, ax=axes[0], color='steelblue')\n",
+    "axes[0].axvline(0.8, color='red', linestyle='--', label='cutoff 0.8')\n",
+    "axes[0].set(title='Per-residue confidence (0–1 scale)',\n",
+    "            xlabel='exp(log_p / L)', ylabel='# peptides')\n",
+    "axes[0].legend()\n",
+    "\n",
+    "sns.boxplot(data=real, x='protease', y='conf_per_aa', ax=axes[1],\n",
+    "            order=summary.index.tolist(), color='lightsteelblue')\n",
+    "axes[1].axhline(0.8, color='red', linestyle='--')\n",
+    "axes[1].set(title='Per-residue confidence by protease', xlabel='', ylabel='exp(log_p / L)')\n",
+    "axes[1].tick_params(axis='x', rotation=35)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "n_hi = (real['conf_per_aa'] > 0.8).sum()\n",
+    "print(f'Peptides with per-residue conf > 0.8: {n_hi} ({n_hi/len(real):.1%})')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-len",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "sns.boxplot(data=real, x='protease', y='pep_len', ax=ax,\n",
+    "            order=summary.index.tolist(), color='peachpuff')\n",
+    "ax.set(title='Peptide length distribution by protease', xlabel='', ylabel='peptide length (aa)')\n",
+    "ax.tick_params(axis='x', rotation=35)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "print('Median peptide length per protease:')\n",
+    "print(real.groupby('protease')['pep_len'].median().sort_values(ascending=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-overlap",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Jaccard similarity of peptide sets between protease pairs.\n",
+    "# We WANT low off-diagonal Jaccard — different proteases should be complementary.\n",
+    "peps_by_protease = {p: set(real[real.protease == p].preds.unique())\n",
+    "                    for p in real.protease.unique()}\n",
+    "ps = sorted(peps_by_protease.keys())\n",
+    "n = len(ps)\n",
+    "J = np.zeros((n, n))\n",
+    "for i, p1 in enumerate(ps):\n",
+    "    for j, p2 in enumerate(ps):\n",
+    "        a, b = peps_by_protease[p1], peps_by_protease[p2]\n",
+    "        J[i, j] = len(a & b) / max(1, len(a | b))\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6.5, 5.5))\n",
+    "sns.heatmap(J, annot=True, fmt='.2f', cmap='Blues',\n",
+    "            xticklabels=ps, yticklabels=ps, ax=ax,\n",
+    "            cbar_kws={'label': 'Jaccard similarity'})\n",
+    "ax.set_title('Peptide overlap between proteases')\n",
+    "plt.xticks(rotation=35); plt.tight_layout(); plt.show()\n",
+    "\n",
+    "union = set().union(*peps_by_protease.values())\n",
+    "print(f'\\nTotal unique peptides across all proteases: {len(union)}')\n",
+    "for p in ps:\n",
+    "    print(f'  {p:14s}: {len(peps_by_protease[p]):4d} unique peptides')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preasm-cov",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick coverage estimate: for each high-confidence peptide, find all exact substring\n",
+    "# matches against the nb6 reference. This is the assembly-free LOWER BOUND.\n",
+    "HIGH_CONF = real[real['conf_per_aa'] > 0.8]\n",
+    "covered_pre = np.zeros(len(NB_REF), dtype=int)\n",
+    "matched_peptides = 0\n",
+    "for pep in HIGH_CONF['preds'].unique():\n",
+    "    start, found = 0, False\n",
+    "    while True:\n",
+    "        idx = NB_REF.find(pep, start)\n",
+    "        if idx < 0: break\n",
+    "        covered_pre[idx:idx + len(pep)] += 1\n",
+    "        start = idx + 1\n",
+    "        found = True\n",
+    "    if found:\n",
+    "        matched_peptides += 1\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 3))\n",
+    "ax.bar(range(len(NB_REF)), covered_pre, width=1.0, color='steelblue')\n",
+    "ax.set(xlabel=f'position in {SAMPLE_NAME} reference', ylabel='# peptide matches',\n",
+    "       title='Pre-assembly coverage by exact-match high-confidence peptides')\n",
+    "ax.spines[['top', 'right']].set_visible(False)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "\n",
+    "frac = (covered_pre > 0).mean()\n",
+    "n_uniq_high = HIGH_CONF['preds'].nunique()\n",
+    "print(f'High-confidence unique peptides: {n_uniq_high}')\n",
+    "print(f'  ...matching the {SAMPLE_NAME} reference exactly: {matched_peptides}')\n",
+    "print(f'Reference positions covered by ≥1 high-confidence peptide: '\n",
+    "      f'{(covered_pre > 0).sum()} / {len(NB_REF)} ({frac:.1%})')\n",
+    "print('\\nThis is a LOWER BOUND — assembly will chain peptides via overlapping ends.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "preasm-md",
+   "metadata": {},
+   "source": [
+    "**What to look at**:\n",
+    "- **Per-residue confidence**: how many peptides survive a 0.8 cutoff? If very few, we should relax it.\n",
+    "- **Peptide length**: Trypsin / LysC give short, regular peptides; ProteinaseK / Elastase give a wider distribution. Mixing proteases is how we cover regions that one protease misses.\n",
+    "- **Overlap heatmap**: high off-diagonal Jaccard means two proteases are redundant. We *want* low off-diagonal values so the panel covers more of the protein.\n",
+    "- **Pre-assembly coverage**: rough preview of where assembly will succeed. If a region is dark here, the greedy chain has very little chance to recover it — and CDR3 is almost always the dark spot.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec5-md",
+   "metadata": {},
+   "source": [
+    "## 5. The greedy assembly algorithm\n",
+    "\n",
+    "We re-implement the **greedy mode** of [InstaNexus](https://github.com/Multiomics-Analytics-Group/InstaNexus) inline so the notebook has no native-binary dependency. The full pipeline also runs MMseqs2 clustering + Clustal Omega alignment + a logomaker consensus step on top of greedy contigs — we skip those here to keep the moving parts small. Discussion at the end covers when those extra steps actually help.\n",
+    "\n",
+    "**The core idea** (greedy assembly of a set of peptides):\n",
+    "1. For every pair of peptides (A, B), find the **largest suffix-of-A == prefix-of-B** of length ≥ `min_overlap`.\n",
+    "2. Sort all such overlaps by length, descending.\n",
+    "3. Greedily merge the highest-scoring pair first; each peptide can be used at most once per round.\n",
+    "4. Repeat until no more merges are possible (or until we hit `MAX_ITERATIONS`).\n",
+    "\n",
+    "After per-protease assembly we get contigs. We then **scaffold** by pooling contigs across proteases and re-running the same greedy logic with substring deduplication between rounds.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "asm-helpers-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_sliding_overlaps(sequences, min_overlap):\n",
+    "    '''All pairs (i, j) with their largest suffix-of-i == prefix-of-j overlap (≥ min_overlap).'''\n",
+    "    overlaps = []\n",
+    "    for i, seq_a in enumerate(sequences):\n",
+    "        for j, seq_b in enumerate(sequences):\n",
+    "            if i == j:\n",
+    "                continue\n",
+    "            max_search = min(len(seq_a), len(seq_b))\n",
+    "            for length in range(max_search, min_overlap - 1, -1):\n",
+    "                if seq_a[-length:] == seq_b[:length]:\n",
+    "                    overlaps.append((i, j, length))\n",
+    "                    break   # only the LARGEST overlap per pair\n",
+    "    return overlaps\n",
+    "\n",
+    "\n",
+    "def merge_with_overhang(seq_a, seq_b, overlap_len):\n",
+    "    '''Merge a and b given suffix(a) == prefix(b). Handles substring containment.'''\n",
+    "    if seq_a in seq_b:\n",
+    "        return seq_b\n",
+    "    if seq_b in seq_a:\n",
+    "        return seq_a\n",
+    "    for i in range(len(seq_a) - overlap_len + 1):\n",
+    "        suffix = seq_a[i:]\n",
+    "        if seq_b.startswith(suffix):\n",
+    "            return seq_a[:i] + seq_b\n",
+    "    return seq_a + seq_b[overlap_len:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "asm-helpers-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def assemble_contigs_greedy(peptides, min_overlap, max_iterations=50):\n",
+    "    '''Iterative greedy merging until convergence or max_iterations.'''\n",
+    "    contigs = list(peptides)\n",
+    "    for _ in range(max_iterations):\n",
+    "        overlaps = find_sliding_overlaps(contigs, min_overlap)\n",
+    "        if not overlaps:\n",
+    "            break\n",
+    "        overlaps.sort(key=lambda x: x[2], reverse=True)\n",
+    "        new_contigs = []\n",
+    "        used = set()\n",
+    "        for i, j, ovl in overlaps:\n",
+    "            if i in used or j in used:\n",
+    "                continue\n",
+    "            new_contigs.append(merge_with_overhang(contigs[i], contigs[j], ovl))\n",
+    "            used.update([i, j])\n",
+    "        if not new_contigs:\n",
+    "            break\n",
+    "        remaining = [c for k, c in enumerate(contigs) if k not in used]\n",
+    "        contigs = new_contigs + remaining\n",
+    "    return contigs\n",
+    "\n",
+    "\n",
+    "def remove_substring_contigs(contigs):\n",
+    "    '''Drop contigs that are substrings of longer contigs.'''\n",
+    "    contigs = sorted(set(contigs), key=len, reverse=____)    # TODO_8: we want to keep the LONGEST contigs and drop their substrings. Should the sort be ascending or descending? Hint: we iterate over `contigs` and accept each unless it is already a substring of something we've kept.\n",
+    "    keep = []\n",
+    "    for c in contigs:\n",
+    "        if not any(c != c2 and c in c2 for c2 in keep):\n",
+    "            keep.append(c)\n",
+    "    return keep"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "asm-helpers-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scaffold_iterative_greedy(contigs, min_overlap, size_threshold, max_rounds=2):\n",
+    "    '''Iteratively scaffold a pool of contigs into a smaller set of longer scaffolds.'''\n",
+    "    def clean(seqs):\n",
+    "        seqs = list(set(seqs))\n",
+    "        seqs = [s for s in seqs if len(s) > size_threshold]\n",
+    "        return sorted(seqs, key=len, reverse=True)\n",
+    "\n",
+    "    current = clean(contigs)\n",
+    "    for round_idx in range(max_rounds):\n",
+    "        overlaps = find_sliding_overlaps(current, min_overlap)\n",
+    "        combined = [merge_with_overhang(current[i], current[j], ovl)\n",
+    "                    for i, j, ovl in overlaps]\n",
+    "        next_round = clean(remove_substring_contigs(combined + current))\n",
+    "        if len(next_round) == len(current):\n",
+    "            break\n",
+    "        current = next_round\n",
+    "    return current"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec6-md",
+   "metadata": {},
+   "source": [
+    "## 6. Filter peptides and run the assembly on nb6\n",
+    "\n",
+    "**Pipeline**: filter by confidence → drop contaminants → per-protease greedy assembly → cross-protease scaffolding.\n",
+    "\n",
+    "We use a small **inline contaminants set** — trypsin self-digest, common keratin, BSA — typical lab MS contaminants. Any predicted peptide that is a substring of a contaminant sequence is discarded.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "filter-peps",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hyperparameters — try changing these and re-running!\n",
+    "CONF_CUTOFF    = ___    # TODO_1: per-residue confidence cutoff for keeping a peptide. Try 0.8 first; relax to 0.7 if very few peptides survive, tighten to 0.9 to keep only the cleanest predictions.\n",
+    "MIN_OVERLAP    = _      # TODO_2: minimum AA overlap to chain two peptides. 2 = many false joins; 5 = very few chains. Try 3.\n",
+    "SIZE_THRESHOLD = _      # TODO_3: discard contigs shorter than this when scaffolding. Smaller protein → less redundancy → lower threshold. Try 8 for a ~150-aa nanobody.\n",
+    "\n",
+    "CONTAMINANTS = [\n",
+    "    # Trypsin self-digest fragment\n",
+    "    'VVGGYTCAANSIPYQVSLNSGSHFCGGSLINSQWVVSAAHCYKSRIQVRLGEHNIDVLEGNEQFINAAKIIKHPNFDR',\n",
+    "    # Human keratin K1 fragment\n",
+    "    'MSRQFSSRSGYRSGGGFSSGSAGIINYQRRTTSSSTRRSGGGGGRFSSCGGGGGSFGAGGGFGSRSLVNLGGSKSISIS',\n",
+    "    # BSA fragment\n",
+    "    'MKWVTFISLLLLFSSAYSRGVFRRDTHKSEIAHRFKDLGEEHFKGLVLIAFSQYLQQCPFDEHVKLVNELTEFAKTCVADESHAGCEK',\n",
+    "]\n",
+    "\n",
+    "def is_contaminant(peptide):\n",
+    "    return any(peptide in c for c in CONTAMINANTS)\n",
+    "\n",
+    "filtered = real[real['conf_per_aa'] > CONF_CUTOFF].copy()\n",
+    "n_before = len(filtered)\n",
+    "filtered = filtered[~filtered['preds'].apply(is_contaminant)]\n",
+    "n_after = len(filtered)\n",
+    "print(f'High-confidence peptides       : {n_before}')\n",
+    "print(f'... after contaminant removal  : {n_after}')\n",
+    "print(f'Discarded as contaminants      : {n_before - n_after}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "per-protease-asm",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Per-protease greedy assembly\n",
+    "contigs_by_protease = {}\n",
+    "for protease, group in tqdm(filtered.groupby('protease'), desc='greedy per protease'):\n",
+    "    peps = group['preds'].unique().tolist()\n",
+    "    contigs = assemble_contigs_greedy(peps, min_overlap=MIN_OVERLAP)\n",
+    "    contigs = remove_substring_contigs(contigs)\n",
+    "    contigs_by_protease[protease] = contigs\n",
+    "\n",
+    "print('\\nContigs per protease (top 3 by length shown):')\n",
+    "for p, cs in contigs_by_protease.items():\n",
+    "    longest = sorted(cs, key=len, reverse=True)[:3]\n",
+    "    print(f'  {p:14s}: {len(cs):3d} contigs, longest={len(longest[0]) if longest else 0} aa')\n",
+    "    for c in longest:\n",
+    "        print(f'      ({len(c):3d}) {c[:80]}{\"…\" if len(c) > 80 else \"\"}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cross-protease-scaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pool all contigs across proteases → scaffold iteratively\n",
+    "all_contigs = [c for cs in contigs_by_protease.values() for c in cs]\n",
+    "print(f'Pooled contigs (all proteases): {len(all_contigs)}')\n",
+    "\n",
+    "scaffolds = scaffold_iterative_greedy(all_contigs,\n",
+    "                                       min_overlap=MIN_OVERLAP,\n",
+    "                                       size_threshold=SIZE_THRESHOLD)\n",
+    "\n",
+    "print(f'\\nFinal scaffolds: {len(scaffolds)}')\n",
+    "for i, s in enumerate(sorted(scaffolds, key=len, reverse=True)[:10]):\n",
+    "    print(f'  #{i+1}  ({len(s):3d} aa)  {s[:90]}{\"…\" if len(s) > 90 else \"\"}')\n",
+    "\n",
+    "print(f'\\n✓ Greedy assembly complete — {len(scaffolds)} scaffolds, longest {max(len(s) for s in scaffolds) if scaffolds else 0} aa.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec7-md",
+   "metadata": {},
+   "source": [
+    "## 7. Map scaffolds onto the nb6 reference\n",
+    "\n",
+    "Pairwise-align every scaffold against the known nb6 sequence, then plot a **coverage track** with the canonical VHH CDR1, CDR2 and CDR3 regions highlighted.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cov-plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Bio import pairwise2\n",
+    "\n",
+    "# Approximate CDR boundaries for VHH (Kabat-ish numbering applied to the framework).\n",
+    "# For production work use ANARCI or IMGT.\n",
+    "CDR1 = (__, __)    # TODO_4: CDR1 of a VHH framework runs roughly from position 25 to position 35 (Kabat-ish numbering). Fill the boundaries.\n",
+    "CDR2 = (49, 58)\n",
+    "WGQ  = NB_REF.find('WGQGTQ')\n",
+    "CDR3 = (__, WGQ if WGQ > 0 else ___)    # TODO_5: CDR3 begins right after the second Cys (~position 95) and ends just before the WGQGTQ motif. Fill in both numbers — the second is a fallback length if WGQGTQ is missing.\n",
+    "\n",
+    "def coverage_mask(seqs):\n",
+    "    covered = np.zeros(len(NB_REF), dtype=int)\n",
+    "    for q in seqs:\n",
+    "        if not q: continue\n",
+    "        aln = pairwise2.align.localxs(NB_REF, q, ___, ___, one_alignment_only=True)    # TODO_6: gap-open and gap-extend penalties (both negative). -2 and -1 are reasonable defaults; make them more negative to discourage gaps further.\n",
+    "        if not aln: continue\n",
+    "        target_aln, query_aln, _, start, end = aln[0]\n",
+    "        ti = 0\n",
+    "        for tc, qc in zip(target_aln, query_aln):\n",
+    "            if tc != '-':\n",
+    "                if qc != '-' and ti >= start and ti < end:\n",
+    "                    covered[ti] += 1\n",
+    "                ti += 1\n",
+    "    return covered\n",
+    "\n",
+    "scaffold_cov = coverage_mask(scaffolds)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(14, 3.5))\n",
+    "ax.bar(range(len(NB_REF)), scaffold_cov, width=1.0, color='#1f77b4')\n",
+    "ax.set_ylabel('# scaffolds covering')\n",
+    "ymax = max(1, ax.get_ylim()[1])\n",
+    "for cdr, name in zip([CDR1, CDR2, CDR3], ['CDR1', 'CDR2', 'CDR3']):\n",
+    "    ax.axvspan(cdr[0], cdr[1], color='red', alpha=0.12)\n",
+    "    ax.text((cdr[0]+cdr[1])/2, ymax*0.9, name, ha='center', fontsize=9, color='darkred')\n",
+    "ax.spines[['top','right']].set_visible(False)\n",
+    "ax.set_xlabel(f'position in {SAMPLE_NAME} reference')\n",
+    "ax.set_title(f'Greedy-assembly scaffold coverage of {SAMPLE_NAME}')\n",
+    "plt.tight_layout(); plt.savefig(WORK/f'{SAMPLE_NAME}_coverage.png', dpi=150, bbox_inches='tight'); plt.show()\n",
+    "\n",
+    "print(f'Reference length: {len(NB_REF)} aa')\n",
+    "print(f'Positions covered by ≥1 scaffold: {int((scaffold_cov > 0).sum())} ({(scaffold_cov > 0).mean():.1%})')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cov-md",
+   "metadata": {},
+   "source": [
+    "**Reading the track**:\n",
+    "- Tall bars = high redundancy at that position. Good.\n",
+    "- Dark gaps in CDR3 (the rightmost red band) are expected — that's the hypervariable loop.\n",
+    "- Dark gaps OUTSIDE the CDRs are bad: usually missed cleavage sites, low-signal protease, or contamination.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec8-md",
+   "metadata": {},
+   "source": [
+    "## 8. Best scaffold vs. reference — identity over the variable domain\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "best-scaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Bio.pairwise2 import format_alignment\n",
+    "\n",
+    "def best_pick(seqs):\n",
+    "    '''Return (seq, identity_over_VHH, alignment) of the scaffold with the highest\n",
+    "    identity to the nb6 variable domain (residues 0..WGQ).'''\n",
+    "    variable = NB_REF[:WGQ if WGQ > 0 else 120]\n",
+    "    best = ('', 0.0, None)\n",
+    "    for s in seqs:\n",
+    "        if not s: continue\n",
+    "        aln = pairwise2.align.globalxs(variable, s, -2, -1, one_alignment_only=True)\n",
+    "        if not aln: continue\n",
+    "        t, q, _, _, _ = aln[0]\n",
+    "        matches = sum(1 for a, b in zip(t, q) if a == b and a != '-')\n",
+    "        ident = matches / max(1, sum(1 for a in t if a != '-'))\n",
+    "        if ident > best[1]:\n",
+    "            best = (s, ident, aln[0])\n",
+    "    return best\n",
+    "\n",
+    "best_seq, best_ident, best_aln = best_pick(scaffolds)\n",
+    "print(f'Best scaffold identity to {SAMPLE_NAME} variable domain: {best_ident:.1%}')\n",
+    "print(f'Scaffold length: {len(best_seq)} aa\\n')\n",
+    "if best_aln:\n",
+    "    print(format_alignment(*best_aln, full_sequences=False)[:2400])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec9-md",
+   "metadata": {},
+   "source": [
+    "## 9. (Optional stretch) Close the loop with ESM-2\n",
+    "\n",
+    "From Module 1: take the best scaffold and the true reference, embed both with ESM-2, compare. If the assembly is mostly right outside CDR3, the embeddings should be very close.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "esm-closure",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    import torch\n",
+    "    from transformers import AutoTokenizer, AutoModel\n",
+    "\n",
+    "    MODEL_NAME = 'facebook/esm2_t6_8M_UR50D'\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)\n",
+    "    model = AutoModel.from_pretrained(MODEL_NAME).eval()\n",
+    "\n",
+    "    @torch.no_grad()\n",
+    "    def embed(seq):\n",
+    "        x = tokenizer(seq, return_tensors='pt')\n",
+    "        h = model(**x).last_hidden_state[0, 1:-1].mean(0).numpy()\n",
+    "        return h / ___    # TODO_7: to make a dot product equal cosine similarity, normalise the vector by its L2 norm. Use `np.linalg.norm(h)`.\n",
+    "\n",
+    "    ref_emb = embed(NB_REF)\n",
+    "    if best_seq:\n",
+    "        scaf_emb = embed(best_seq)\n",
+    "        cos = float(ref_emb @ scaf_emb)\n",
+    "        print(f'Cosine similarity of best scaffold to {SAMPLE_NAME} reference: {cos:.4f}')\n",
+    "        print('(1.0 = identical, 0.0 = orthogonal; expect 0.95+ on a successful assembly.)')\n",
+    "    else:\n",
+    "        print('No scaffold to compare.')\n",
+    "except Exception as e:\n",
+    "    print('Skipping ESM closure step:', e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "discussion-md",
+   "metadata": {},
+   "source": [
+    "## 10. Discussion prompts\n",
+    "\n",
+    "1. **Hyperparameter sweep**: try `CONF_CUTOFF ∈ {0.7, 0.8, 0.9}`, `MIN_OVERLAP ∈ {2, 3, 5}`, `SIZE_THRESHOLD ∈ {5, 8, 12}` and re-run from Section 6. Which combination maximises identity to the reference? Which produces the longest scaffold?\n",
+    "2. **Where did the assembly fail?** Look at the coverage track. Is CDR3 the worst region? Why is it so hard *both* for MS de novo *and* for MSA-based methods (Module 1 slide 10)?\n",
+    "3. **Which protease pulled its weight?** Look back at the per-protease contig list (Section 6). Which protease contributed the longest contigs? Which one underperformed? Could you have spent your beam time better?\n",
+    "4. **No reference?** In a real nanobody discovery campaign you don't *have* the reference. How would you judge assembly quality without one? \n",
+    "5. **Pre-assembly checks (Section 4) vs. post-assembly result**: did the greedy chain close gaps that the exact-match preview missed? Where?\n",
+    "6. **What did we skip?** The full InstaNexus pipeline runs MMseqs2 clustering, Clustal Omega alignment and a logomaker consensus on top of greedy contigs. When would those extra steps help? Hint: multiple competing scaffolds covering the same region.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "end",
+   "metadata": {},
+   "source": [
+    "## End of Exercise 2 — end of the 4-hour module\n",
+    "\n",
+    "You have:\n",
+    "- Run a **foundation model** (ESM-2) on protein sequences and used the embeddings for visualisation, classification, zero-shot variant scoring, and a regression task (Exercise 1).\n",
+    "- **Inspected real InstaNovo predictions** on a nanobody MS dataset — log-prob distribution, per-residue confidence on a 0–1 scale, peptide length by protease, inter-protease Jaccard overlap, and a quick pre-assembly coverage check.\n",
+    "- **Implemented and ran greedy assembly** inline — per-protease contigs followed by cross-protease scaffolding — and seen how a ~100-line algorithm reconstructs much of a 153-aa nanobody from messy de novo peptide predictions.\n",
+    "- Compared the assembled scaffolds against the **known reference** and visualised coverage with CDR1/2/3 highlighted.\n",
+    "- **Closed the loop** by re-embedding the best scaffold with ESM-2 and measuring cosine similarity to the reference.\n",
+    "\n",
+    "Same paradigm — foundation model pretraining → embeddings or scoring → downstream task — across three data modalities (protein sequences, mass spectra, and your own assembly output). That is the foundation-model paradigm in biology.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 
 dependencies = [
   "biopython>=1.85",
+  "numpy>=1.26",
   "pandas>=2.3.1",
   "tqdm>=4.67.1",
   "seaborn>=0.13.2",
@@ -51,7 +52,7 @@ docs = [
 lint = ["mypy", "ruff", "codespell"]
 
 # local development options
-dev = ["ruff", "pytest", "jupytext", "pre-commit"]
+dev = ["ruff", "pytest", "jupytext", "pre-commit", "jupyter", "nbconvert", "ipykernel"]
 
 [project.urls]
 Homepage = "https://github.com/Multiomics-Analytics-Group/InstaNexus"

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -45,12 +59,85 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/ba4e4ca8d149f8dcc0d952ac0967089e1d759c7e5fcf0865a317eb680fbb/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6dca33a9859abf613e22733131fc9194091c1fa7cb3e131c143056b4856aa47e", size = 24549, upload-time = "2025-07-30T10:02:00.101Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/82/9b2386cc75ac0bd3210e12a44bfc7fd1632065ed8b80d573036eecb10442/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:21378b40e1b8d1655dd5310c84a40fc19a9aa5e6366e835ceb8576bf0fea716d", size = 25539, upload-time = "2025-07-30T10:02:00.929Z" },
+    { url = "https://files.pythonhosted.org/packages/31/db/740de99a37aa727623730c90d92c22c9e12585b3c98c54b7960f7810289f/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d588dec224e2a83edbdc785a5e6f3c6cd736f46bfd4b441bbb5aa1f5085e584", size = 28467, upload-time = "2025-07-30T10:02:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/71/7a/47c4509ea18d755f44e2b92b7178914f0c113946d11e16e626df8eaa2b0b/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5acb4e41090d53f17ca1110c3427f0a130f944b896fc8c83973219c97f57b690", size = 27355, upload-time = "2025-07-30T10:02:02.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/82/82745642d3c46e7cea25e1885b014b033f4693346ce46b7f47483cf5d448/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:da0c79c23a63723aa5d782250fbf51b768abca630285262fb5144ba5ae01e520", size = 29187, upload-time = "2025-07-30T10:02:03.674Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
 ]
 
 [[package]]
@@ -124,6 +211,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/63/10/5a2794c558ef6058da8413ad0ffeee2c090d250b9e5d31009faadfe84fc5/biopython-1.87-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c8da2d44a4b912c7550a051a5ff4bb72a61decc9c4b19ea92cba4c02fffb143c", size = 3283916, upload-time = "2026-03-30T11:38:54.609Z" },
     { url = "https://files.pythonhosted.org/packages/12/cd/b18b40e9de9475cfd59f7c30dea6bab7f337758f617d3f5853b1ece8abee/biopython-1.87-cp314-cp314t-win32.whl", hash = "sha256:3670d76759c6cb53ba617f9823d3a438c1aa5415abef6addd29cb81d61d7b312", size = 2712763, upload-time = "2026-03-30T11:39:00.551Z" },
     { url = "https://files.pythonhosted.org/packages/8e/12/478812ef9c8484f96253ba8fb42b466db4f4594c3bb352a5f4318de01704/biopython-1.87-cp314-cp314t-win_amd64.whl", hash = "sha256:331c4151608a1d8406eff0d3c52a0ff1fa3e82604fc85f11c696c562919fb161", size = 2751774, upload-time = "2026-03-30T11:38:57.678Z" },
+]
+
+[[package]]
+name = "bleach"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
 ]
 
 [[package]]
@@ -581,6 +685,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -718,6 +831,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -769,6 +891,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -829,6 +988,8 @@ dependencies = [
     { name = "matplotlib" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "plotly" },
@@ -841,7 +1002,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "ipykernel" },
+    { name = "jupyter" },
     { name = "jupytext" },
+    { name = "nbconvert" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
@@ -868,14 +1032,18 @@ lint = [
 requires-dist = [
     { name = "biopython", specifier = ">=1.85" },
     { name = "codespell", marker = "extra == 'lint'" },
+    { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "ipywidgets", marker = "extra == 'docs'" },
+    { name = "jupyter", marker = "extra == 'dev'" },
     { name = "jupytext", marker = "extra == 'dev'" },
     { name = "jupytext", marker = "extra == 'docs'" },
     { name = "logomaker", specifier = ">=0.8" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "mypy", marker = "extra == 'lint'" },
     { name = "myst-nb", marker = "extra == 'docs'" },
+    { name = "nbconvert", marker = "extra == 'dev'" },
     { name = "networkx", specifier = ">=3.3" },
+    { name = "numpy", specifier = ">=1.26" },
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "plotly", specifier = ">=6.2.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
@@ -1031,6 +1199,18 @@ wheels = [
 ]
 
 [[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1064,6 +1244,24 @@ wheels = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/4b/6f8906aaf67d501e259b0adab4d312945bb7211e8b8d4dcc77c92320edaa/json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb", size = 52656, upload-time = "2026-03-27T22:50:48.108Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/42/cf027b4ac873b076189d935b135397675dac80cb29acb13e1ab86ad6c631/json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a", size = 36271, upload-time = "2026-03-27T22:50:47.073Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1078,6 +1276,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
 ]
 
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
+]
+
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
@@ -1088,6 +1299,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "jupyter"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-console" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+    { name = "notebook" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/f3/af28ea964ab8bc1e472dba2e82627d36d470c51f5cd38c37502eeffaa25e/jupyter-1.1.1.tar.gz", hash = "sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a", size = 5714959, upload-time = "2024-08-30T07:15:48.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/64/285f20a31679bf547b75602702f7800e74dbabae36ef324f716c02804753/jupyter-1.1.1-py2.py3-none-any.whl", hash = "sha256:7a59533c22af65439b24bbe60373a4e95af8f16ac65a6c00820ad378e3f7cc83", size = 2657, upload-time = "2024-08-30T07:15:47.045Z" },
 ]
 
 [[package]]
@@ -1126,6 +1354,27 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-console"
+version = "6.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "pyzmq" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2d/e2fd31e2fc41c14e2bcb6c976ab732597e907523f6b2420305f9fc7fdbdb/jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539", size = 34363, upload-time = "2023-03-06T14:13:31.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/77/71d78d58f15c22db16328a476426f7ac4a60d3a5a7ba3b9627ee2f7903d4/jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485", size = 24510, upload-time = "2023-03-06T14:13:28.229Z" },
+]
+
+[[package]]
 name = "jupyter-core"
 version = "5.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1136,6 +1385,132 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "overrides", marker = "python_full_version < '3.12'" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/a0/eb3c511f54df7b54ca5fc7bff3f4d2277d69052d6a7f521643dfed5279d6/jupyter_server-2.19.0.tar.gz", hash = "sha256:1731236bc32b680223e1ceb9d68209a845203475012ef68773a81434b46a31a7", size = 754561, upload-time = "2026-05-29T11:21:26.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/78/d2881e68894cecdcd05912a9c585cfb776ef1fb38b62c8dba98f12ab3adc/jupyter_server-2.19.0-py3-none-any.whl", hash = "sha256:cb76591b76d7093584c2ad2ae72ac3d58614a4b597507a1bb04e1f9f683cf9ea", size = 392244, upload-time = "2026-05-29T11:21:23.871Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.5.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "setuptools" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/74/089613e6099e851a6130816f2df592c839d8565f8746a701edada05a33e4/jupyterlab-4.5.8.tar.gz", hash = "sha256:af54d7242cc689a1e6c3ad213cc9b6d9781787d9ec67c52ec9a8f4707088cadd", size = 23994076, upload-time = "2026-06-04T12:32:12.906Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/d1/56a400100559cbf154a23cd29989261941ae5c9f743898fc10e8a5508b7c/jupyterlab-4.5.8-py3-none-any.whl", hash = "sha256:7d514c856d0d607601ec7692374da4f26e2aaf3b6e7cd363136b422a50588d6c", size = 12449443, upload-time = "2026-06-04T12:32:08.442Z" },
+]
+
+[[package]]
+name = "jupyterlab-pygments"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
 ]
 
 [[package]]
@@ -1287,6 +1662,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/44/2b5b95b7aa39fb2d8d9d956e0f3d5d45aef2ae1d942d4c3ffac2f9cfed1a/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be4a51a55833dc29ab5d7503e7bcb3b3af3402d266018137127450005cdfe737", size = 79892, upload-time = "2026-03-09T13:15:49.694Z" },
     { url = "https://files.pythonhosted.org/packages/52/7d/7157f9bba6b455cfb4632ed411e199fc8b8977642c2b12082e1bd9e6d173/kiwisolver-1.5.0-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:daae526907e262de627d8f70058a0f64acc9e2641c164c99c8f594b34a799a16", size = 77603, upload-time = "2026-03-09T13:15:50.945Z" },
     { url = "https://files.pythonhosted.org/packages/0a/dd/8050c947d435c8d4bc94e3252f4d8bb8a76cfb424f043a8680be637a57f1/kiwisolver-1.5.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:59cd8683f575d96df5bb48f6add94afc055012c29e28124fcae2b63661b9efb1", size = 73558, upload-time = "2026-03-09T13:15:52.112Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -1623,6 +2007,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mistune"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/84/620cc3f7e3adf6f5067e10f4dbae71295d8f9e16d5d3f9ef97c40f2f592c/mistune-3.2.1.tar.gz", hash = "sha256:7c8e5501d38bac1582e067e46c8343f17d57ea1aaa735823f3aba1fd59c88a28", size = 98003, upload-time = "2026-05-03T14:33:22.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/7f/a946aa4f8752b37102b41e64dca18a1976ac705c3a0d1dfe74d820a02552/mistune-3.2.1-py3-none-any.whl", hash = "sha256:78cdb0ba5e938053ccf63651b352508d2efa9411dc8810bfb05f2dc5140c0048", size = 53749, upload-time = "2026-05-03T14:33:20.551Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1789,6 +2185,31 @@ wheels = [
 ]
 
 [[package]]
+name = "nbconvert"
+version = "7.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
+]
+
+[[package]]
 name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1851,6 +2272,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "notebook"
+version = "7.5.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/c4/f71f8716f2903e9e817a47f534b9fd84831e155e2acb32c26691c8e06243/notebook-7.5.7.tar.gz", hash = "sha256:d6d59288a25303b25e1dcb71e9b017ec3a785f7d92f38b9bc288ca1970d5b0a8", size = 14171612, upload-time = "2026-06-04T18:33:45.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/4d/b3347f7073a377273531efe4ffc738fc910e93718fd2838c7ebf6736c6af/notebook-7.5.7-py3-none-any.whl", hash = "sha256:1f95f79d117e47d20b5555b5c85a397d2cfecf136978aaab767cf0314b09165b", size = 14583767, upload-time = "2026-06-04T18:33:40.987Z" },
+]
+
+[[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
 ]
 
 [[package]]
@@ -2009,6 +2458,15 @@ wheels = [
 ]
 
 [[package]]
+name = "overrides"
+version = "7.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/b585f53236dec60aba864e050778b25045f857e17f6e5ea0ae95fe80edd2/overrides-7.7.0.tar.gz", hash = "sha256:55158fa3d93b98cc75299b1e67078ad9003ca27945c76162c1c0766d6f91820a", size = 22812, upload-time = "2024-01-27T21:01:33.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/ab/fc8290c6a4c722e5514d80f62b2dc4c4df1a68a41d1364e625c35990fcf3/overrides-7.7.0-py3-none-any.whl", hash = "sha256:c7ed9d062f78b8e4c1a7b70bd8796b35ead4d9f510227ef9c5dc7626c60d7e49", size = 17832, upload-time = "2024-01-27T21:01:31.393Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2150,6 +2608,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
     { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
     { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "pandocfilters"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
 ]
 
 [[package]]
@@ -2325,6 +2792,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -2508,12 +2984,42 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/39/9fcb2d8c796e222ef95ddc0b72dbc8907d9a42eb4d8ea40f6bcf5dfe75bb/pywinpty-3.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:aa231b3e63bf8b97170d0889225c1805390d3839675c6a9398bdc26a4603ee3b", size = 1503049, upload-time = "2026-06-10T06:04:56.16Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/44/c5d5cc8f1e58db1b2c060f96cea1c2ce4e806768647cc22529e17af60eaa/pywinpty-3.0.4-cp310-cp310-win_arm64.whl", hash = "sha256:368323d836edf6b3f81c7b2dab8493d0d6df3796080963bf03109a0e2f6afeb9", size = 240604, upload-time = "2026-06-10T06:03:30.641Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4e/a0d067b2a8762cf85dd9c409c9ad6650621ff6fb5b29c5d6834f5401890c/pywinpty-3.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:7648ef6c572896859efcba546026ceed6c6790deb7891246cbacc3d31e1eed56", size = 1503165, upload-time = "2026-06-10T06:04:18.162Z" },
+    { url = "https://files.pythonhosted.org/packages/20/31/393eed64a7d1951e155bc34039f47fc1af661442f356dae9b0a514a2e087/pywinpty-3.0.4-cp311-cp311-win_arm64.whl", hash = "sha256:27af19cb9f633ae04bf4062fc8e89042d4d60ea99678e8b44ea1f412ac2b4a77", size = 240920, upload-time = "2026-06-10T06:03:27.659Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/55/e5a95c61e693941458dbf6ed8164c766e6166802364efabe1d610533e6b7/pywinpty-3.0.4-cp312-cp312-win_amd64.whl", hash = "sha256:3c8af7d7f37e7d2a2bcfd5625fbd6158b49fef620b6d10682d081f63b47c6aab", size = 1501465, upload-time = "2026-06-10T06:04:01.202Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/672de7fafae62dfbc0b57bb5d825bfcca97cc3050fe090d222edc2b7f756/pywinpty-3.0.4-cp312-cp312-win_arm64.whl", hash = "sha256:8b26b58eff31fea6018afe6e1eba47382ccee1e879376b09a591ff3259d5a4e3", size = 238463, upload-time = "2026-06-10T06:01:45.42Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/77/f5db2802d2583af7b52eec513cbcabc521daa5fe2cb57380b2e1245cac64/pywinpty-3.0.4-cp313-cp313-win_amd64.whl", hash = "sha256:b63b22ab53fea5ae3f10a55180efb8d089be82632256d9a783c1f6dbfc3faf29", size = 1501059, upload-time = "2026-06-10T06:03:34.551Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ca/4b554caf70f2821b3dd5f58208b584a821eeabff56643049d1938dca9306/pywinpty-3.0.4-cp313-cp313-win_arm64.whl", hash = "sha256:f8fae0cdbf3d7c9a3e72490d2460dedc4c050fd1eff5d3b715097bea89cb9239", size = 237983, upload-time = "2026-06-10T06:02:24.811Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/dc/a087e1d8ad4bc5c8ae61fb23cb104fadc55e9242c22dd81620483b648b1e/pywinpty-3.0.4-cp313-cp313t-win_amd64.whl", hash = "sha256:397e12405c5c8749bac56bb447453d6200a515cf8ef3802e1a83dd3fb2e7384a", size = 1500389, upload-time = "2026-06-10T06:03:39.879Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0d/e10f2516703e3141d84948a46ec253d47c8ad04e78ec37e508f7c7a8a9a2/pywinpty-3.0.4-cp313-cp313t-win_arm64.whl", hash = "sha256:1ab08db89053c0f31405c842c129c8f1a2610b463861ac22202c763cdbb16d75", size = 237037, upload-time = "2026-06-10T06:03:10.917Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/77/39af026e681e350073495155d885b82947a88b29ae7a61f016e1ac8c744e/pywinpty-3.0.4-cp314-cp314-win_amd64.whl", hash = "sha256:b028b4d8ece77a4b35282461234d2e38c472c6dc4be6e5cccdeffcd2776ebf7f", size = 1501228, upload-time = "2026-06-10T06:06:18.748Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/76cc0e1e9fa92ce1dddb3d90d082c5eb0facb1665446019916156e244ba6/pywinpty-3.0.4-cp314-cp314-win_arm64.whl", hash = "sha256:171b60831057b519bc3673970eb970352b99e6efdfd22cad169b7a815699d862", size = 238201, upload-time = "2026-06-10T06:02:33.894Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/86/48fb10e2c7db43461dcc69179e81a648ebf8f350271c8cc079aed65b354b/pywinpty-3.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:3771c364b38a5e4956582ee68d912e35763d78310e362ddce6d390cf5ff94f58", size = 1500583, upload-time = "2026-06-10T06:02:53.12Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/40/a94cf31db8a759ed871c0e9f10f8aa0a042ddc6592f233a26a4c0d757047/pywinpty-3.0.4-cp314-cp314t-win_arm64.whl", hash = "sha256:819eb417254eac67553c93d2f38b12617bb0ebb65e6b840d51fe7e5a4a824646", size = 237067, upload-time = "2026-06-10T06:02:35.677Z" },
 ]
 
 [[package]]
@@ -2680,6 +3186,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
 ]
 
 [[package]]
@@ -3104,6 +3643,24 @@ wheels = [
 ]
 
 [[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "82.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3452,12 +4009,38 @@ wheels = [
 ]
 
 [[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]
@@ -3582,6 +4165,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/63/a5a1628898729bcfb67ea785a152e424d78e0f57dfbba46213a652532d6a/UpSetPlot-0.9.0.tar.gz", hash = "sha256:95b76ac38c624c9dfb1eca1de1a37e30e07e83678b1c57839c943184247b8592", size = 23797, upload-time = "2023-12-31T01:07:59.185Z" }
 
 [[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3613,6 +4205,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Fix NB6.csv download URL (branch plm-and-foundation-models → main)
- Replace !wget with urllib.request for cross-platform data download
- Wrap pip install in Colab detection so Codespace uses uv-managed packages
- Add numpy to core dependencies (used directly in notebooks)
- Add jupyter, nbconvert, ipykernel to dev extras for reproducible execution
- Add exercise2_work/ to .gitignore (notebook runtime working dir)
- Verified: solved notebook executes clean with nbconvert (97.4% nb6 coverage)