### PR TITLE
Update README.md with new features: optimization, conda &  uv enviroments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ This pipeline enables robust reconstruction of critical protein regions, advanci
 - ⚗️ Handles multiple protease digestions (Trypsin, LysC, GluC, etc.)
 - 🧹 Integrated contaminant removal and confidence filtering
 - 🧩 Clustering, alignment, and consensus sequence reconstruction
+- 🎛️ Parallel hyperparameter optimization via the `instanexus-optimize` grid-search CLI
 - 🔗 Integrates with external tools:
   - [MMseqs2](https://github.com/soedinglab/MMseqs2) for fast clustering
   - [Clustal Omega](https://www.ebi.ac.uk/Tools/msa/clustalo/) for high-quality alignment
+- 📦 Reproducible environments via [uv](https://docs.astral.sh/uv/) or conda
 - 📊 Output-ready for downstream analysis and visualization
 
 ---
@@ -74,18 +76,24 @@ This pipeline enables robust reconstruction of critical protein regions, advanci
 | `src/instanexus/clustering.py` | Module for clustering (mmseqs2) |
 | `src/instanexus/alignment.py` | Module for alignment (clustalo) |
 | `src/instanexus/consensus.py` | Module for consensus generation |
-| `src/instanexus/opt/` | Grid search and optimization workflows |
+| `src/instanexus/optimize.py` | Entry point for the `instanexus-optimize` CLI |
+| `scripts/optimization/` | Grid-search and optimization workflows |
 | `tests/` | Pytest unit and integration tests |
 | `pyproject.toml` | Package metadata, dependencies, and entry point |
+| `environment.linux.yml` | Conda environment specification (Linux) |
+| `environment.osx-arm64.yaml` | Conda environment specification (macOS, Apple Silicon) |
 | `.pre-commit-config.yaml` | Pre-commit hook configuration |
 
 ---
 
 ## Installation
 
-InstaNexus requires Python 3.10+, [uv](https://docs.astral.sh/uv/), **MMseqs2**, and **Clustal Omega**.
+InstaNexus requires Python 3.10+, **MMseqs2**, and **Clustal Omega**. You can manage the
+environment with either [uv](https://docs.astral.sh/uv/) or [conda](https://docs.conda.io/)
+(the conda environment files bundle MMseqs2 and Clustal Omega for you).
 
 - [uv](https://docs.astral.sh/uv/) — fast Python package manager
+- [conda](https://docs.conda.io/) / [mamba](https://mamba.readthedocs.io/) — cross-platform package and environment manager
 - [MMseqs2](https://github.com/soedinglab/MMseqs2)
 - [Clustal Omega](https://www.ebi.ac.uk/Tools/msa/clustalo/)
 
@@ -99,7 +107,7 @@ InstaNexus requires Python 3.10+, [uv](https://docs.astral.sh/uv/), **MMseqs2**,
 pip install instanexus
 ```
 
-### Option 2: Install from Source (for Developers)
+### Option 2: Install from Source with uv (for Developers)
 
 #### Clone the repository:
 
@@ -114,9 +122,15 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 #### Sync the environment:
+`uv sync --all-extras` creates a `.venv/` and installs the runtime plus all optional
+(`docs`, `lint`, `dev`) dependencies from `pyproject.toml`/`uv.lock`.
 ```bash
 uv sync --all-extras
 ```
+
+> **Note:** MMseqs2 and Clustal Omega are not Python packages. With uv, install them
+> separately (e.g. via your system package manager) or use the conda option below, which
+> bundles them.
 
 #### Set up pre-commit hooks:
 ```bash
@@ -126,6 +140,32 @@ uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 #### Verify the installation:
 ```bash
 uv run instanexus --help
+```
+
+### Option 3: Install from Source with conda
+
+The conda environment files pin the Python dependencies **and** the external tools
+(MMseqs2, Clustal Omega), so they provide a fully self-contained setup.
+
+```bash
+git clone git@github.com:Multiomics-Analytics-Group/InstaNexus.git
+cd InstaNexus
+
+# Linux
+conda env create -f environment.linux.yml
+
+# macOS (Apple Silicon)
+conda env create -f environment.osx-arm64.yaml
+
+conda activate instanexus
+
+# install InstaNexus itself into the environment
+pip install -e .
+```
+
+Verify the installation:
+```bash
+instanexus --help
 ```
 
 ---
@@ -170,7 +210,43 @@ instanexus \
 
 The results for this specific run will be saved in a unique directory, such as:```outputs/bsa/dbg_c0.9_ks7_mo3_ts12/```
 
+---
 
+## Hyperparameter Optimization
+
+InstaNexus ships with a parallel grid-search optimizer, exposed as the `instanexus-optimize`
+command (entry point for `scripts/optimization/grid_search.py`). It sweeps assembly
+parameters across a grid, evaluates each combination against a reference, and ranks them
+with a normalized **Composite Score** combining Coverage, N50, scaffold count, and maximum
+contig length (see [`scripts/optimization/README.md`](scripts/optimization/README.md) for
+the exact formula).
+
+The search space for each assembly mode (`greedy`, `dbg_weighted`, `multimodal_dbg`) is
+defined in `json/gridsearch_params.json`.
+
+#### Run a grid search:
+```bash
+instanexus-optimize \
+    --input-csv inputs/ma1_cleaned.csv \
+    --metadata-json json/sample_metadata.json \
+    --grid-json json/gridsearch_params.json \
+    --mode dbg_weighted \
+    --chain light \
+    --workers 16
+```
+
+| Flag | Description |
+|---|---|
+| `--input-csv` | Raw or cleaned input CSV (preprocessing runs automatically if no cleaned file exists in `--output-dir`) |
+| `--metadata-json` | Path to `sample_metadata.json` (required for reference protein lookup) |
+| `--grid-json` | Path to `gridsearch_params.json` defining the parameter grid |
+| `--mode` | Assembly mode (`greedy`, `dbg_weighted`, `multimodal_dbg`) |
+| `--chain` | Chain type for antibodies (`light` / `heavy`); omit for single-chain samples |
+| `--workers` | Number of parallel worker processes (default: `8`) |
+| `--output-dir` | Directory to save results (default: `outputs/_grid_search`) |
+
+To sweep multiple samples and modes at once, see `scripts/optimization/run_all_gridsearch.sh`.
+Results can be summarized and visualized with `scripts/optimization/analyze_optimization.py`.
 
 ---
 

--- a/scripts/optimization/README.md
+++ b/scripts/optimization/README.md
@@ -1,0 +1,105 @@
+# Optimization
+
+Parallel hyperparameter optimization for the InstaNexus assembly module.
+
+This folder sweeps assembly parameters across a grid, evaluates each combination against a
+reference, and ranks them with a normalized **Composite Score** (Reverenna et al., bioRxiv
+2025) combining Coverage, N50, scaffold count, and maximum contig length.
+
+## Contents
+
+| File | Description |
+|---|---|
+| `grid_search.py` | Core grid-search optimizer (also exposed as the `instanexus-optimize` CLI) |
+| `analyze_optimization.py` | Aggregates results into summary tables and SVG heatmaps |
+| `run_all_gridsearch.sh` | Batch-runs the grid search across all samples and assembly modes |
+| `run_preprocessing.sh` | Batch-preprocesses raw input CSVs into `inputs/cleaned/` |
+| `debug.py` | Minimal smoke test for imports and a single assembly run |
+
+The parameter grid for each assembly mode (`greedy`, `dbg_weighted`, `multimodal_dbg`) is
+defined in [`json/gridsearch_params.json`](../../json/gridsearch_params.json).
+
+## Running a grid search
+
+Use the installed CLI:
+
+```bash
+instanexus-optimize \
+    --input-csv inputs/ma1_cleaned.csv \
+    --metadata-json json/sample_metadata.json \
+    --grid-json json/gridsearch_params.json \
+    --mode dbg_weighted \
+    --chain light \
+    --workers 16
+```
+
+or run the script directly:
+
+```bash
+python scripts/optimization/grid_search.py \
+    --input-csv inputs/ma1_cleaned.csv \
+    --metadata-json json/sample_metadata.json \
+    --grid-json json/gridsearch_params.json \
+    --mode dbg_weighted \
+    --chain light \
+    --workers 16
+```
+
+### Arguments
+
+| Flag | Default | Description |
+|---|---|---|
+| `--input-csv` | *(required)* | Raw or cleaned input CSV. Preprocessing runs automatically if no cleaned file exists in `--output-dir`. |
+| `--metadata-json` | *(required)* | Path to `sample_metadata.json` (required for reference protein lookup). |
+| `--grid-json` | *(required)* | Path to `gridsearch_params.json` defining the parameter grid. |
+| `--mode` | *(required)* | Assembly mode (`greedy`, `dbg_weighted`, `multimodal_dbg`). |
+| `--chain` | `""` | Chain type for antibodies (`light` / `heavy`); omit for single-chain samples. |
+| `--workers` | `8` | Number of parallel worker processes. |
+| `--output-dir` | `outputs/_grid_search` | Directory to save results. |
+| `--eval-min-identity` | `0.8` | Minimum identity for evaluation mapping. |
+| `--eval-max-mismatches` | `100` | Maximum mismatches for evaluation mapping. |
+
+The preprocessing step (used when no cleaned CSV is present) also accepts optional
+`--conf`, `--fdr`, and `--contaminants-fasta` flags.
+
+## Typical workflow
+
+1. **Preprocess** raw inputs into `inputs/cleaned/` (antibody samples get `--chain light`):
+
+   ```bash
+   bash scripts/optimization/run_preprocessing.sh
+   ```
+
+2. **Sweep** all samples across every assembly mode. Edit the `MODES`, `ANTIBODIES`,
+   `OTHERS`, and `WORKERS` variables at the top of the script to match your data, then:
+
+   ```bash
+   bash scripts/optimization/run_all_gridsearch.sh
+   ```
+
+   Results land in `outputs/_grid_search/<mode>/` and per-run logs in `logs/`.
+
+3. **Analyze** the results into publication-ready tables and heatmaps:
+
+   ```bash
+   python scripts/optimization/analyze_optimization.py
+   ```
+
+   Outputs are written to `outputs/_summary_tables/` and `outputs/_optimization_figures/`.
+
+## Composite Score
+
+Each parameter combination is scored by min-max normalizing the metrics across the grid
+and combining them with fixed weights (Reverenna et al., bioRxiv 2025):
+
+```
+composite_score = 0.5 * coverage_norm
+                + 0.3 * N50_norm
+                + 0.1 * (1 - scaffolds_count_norm)   # inverted: fewer scaffolds = better
+                + 0.1 * max_length_norm
+```
+
+Higher coverage, longer N50, fewer scaffolds, and longer maximum contigs all increase the
+score. `mean_identity` is collected for reporting but is **not** part of this formula. The
+top-ranked combination is the recommended parameter set for that sample and mode, and the
+optimizer prints a ready-to-run `instanexus` command for it.


### PR DESCRIPTION
Updated `README.md` to cover the three new feature areas:

## Optimization
- New Hyperparameter Optimization section (the TOC linked to it but the body had no such section) documenting the `instanexus-optimize` grid-search CLI, its flags, the `gridsearch_params.json` grid, plus `run_all_gridsearch.sh ` and `analyze_optimization.py `.
- Added a Features bullet and fixed the stale `src/instanexus/opt/` row in Repository Structure → `scripts/optimization/` + `src/instanexus/optimize.py`.

## uv environments
- Relabeled the source install as the uv path, clarified that  `uv sync --all-extras` builds `.venv/ ` from `pyproject.toml/uv.lock`, and noted MMseqs2/Clustal Omega aren't pip-installable.

## conda environments
- New Option 3: Install from Source with conda using `environment.linux.yml` / `environment.osx-arm64.yaml` (which bundle MMseqs2 + Clustal Omega), and listed both files in Repository Structure.

## Optimization README

Wrote scripts/optimization/README.md (previously empty) documenting:

- Contents of the folder: `grid_search.py`, `analyze_optimization.py`, `run_all_gridsearch.sh`, `run_preprocessing.sh`, `debug.py `.
- How to run a grid search via both the `instanexus-optimize` CLI and the script directly, with a full argument table (including `--eval-min-identity/--eval-max-mismatches` and the optional preprocessing flags).
- Typical 3-step workflow: preprocess → sweep all samples/modes → analyze, with the output directories each step produces.
- Composite Score: the exact weighted formula from grid_search.py (0.5·coverage + 0.3·N50 + 0.1·(1−scaffolds) + 0.1·max_length), noting `mean_identity` is reported but not scored.

Closes https://github.com/Multiomics-Analytics-Group/InstaNexus/issues/29